### PR TITLE
Major rewrite that now uses single proxy IP per account and not per m…

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -487,3 +487,10 @@ ulimitfd=$(ulimit -n 2>/dev/null)
 if [ -n "$ulimitfd" -a $ulimitfd -lt 131072 ]; then
     ulimit -n 131072
 fi
+
+#
+# In case there are inherited fds, close other than 0,1,2.
+#
+for fd in $(ls /proc/$$/fd/); do
+    [ $fd -gt 2 ] && exec {fd}<&-
+done

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -133,13 +133,13 @@ resolve_ipv4()
     local hname="$1"
 
     # Some retries for resilience.
-    for((i=0;i<3;i++)) {
+    for((i=0;i<=5;i++)) {
         # Resolve hostname to IPv4 address.
-        host_op=$(host -4 -t A "$hname")
+        host_op=$(host -4 -t A "$hname" 2>&1)
         if [ $? -ne 0 ]; then
-            eecho "Failed to resolve ${hname}!"
+            eecho "Failed to resolve ${hname}: $host_op!"
             # Exhausted retries?
-            if [ $i -eq 3 ]; then
+            if [ $i -eq 5 ]; then
                 return 1
             fi
             # Mostly some transient issue, retry after some sleep.
@@ -163,7 +163,7 @@ resolve_ipv4()
         if [ $cnt_ip -eq 0 ]; then
             eecho "host returned 0 address for ${hname}, expected one or more! [$host_op]"
             # Exhausted retries?
-            if [ $i -eq 3 ]; then
+            if [ $i -eq 5 ]; then
                 return 1
             fi
             # Mostly some transient issue, retry after some sleep.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -8,6 +8,7 @@
 APPNAME="aznfs"
 OPTDIR="/opt/microsoft/${APPNAME}"
 LOGFILE="${OPTDIR}/${APPNAME}.log"
+RANDBYTES="${OPTDIR}/randbytes"
 
 #
 # This stores the map of local IP and share name and external blob endpoint IP.
@@ -157,7 +158,7 @@ resolve_ipv4()
         # zones.
         #
         ipv4_addr_all=$(echo "$host_op" | grep " has address " | awk '{print $4}' |\
-                        sort | shuf --random-source=/etc/machine-id)
+                        sort | shuf --random-source=$RANDBYTES)
 
         cnt_ip=$(echo "$ipv4_addr_all" | wc -l)
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,11 +7,11 @@
 
 APPNAME="aznfs"
 OPTDIR="/opt/microsoft/${APPNAME}"
-LOGFILE="${OPTDIR}/${APPNAME}.log" 
+LOGFILE="${OPTDIR}/${APPNAME}.log"
 
-# 
-# This stores the map of local IP and share name and external blob endpoint IP. 
-# 
+#
+# This stores the map of local IP and share name and external blob endpoint IP.
+#
 MOUNTMAP="${OPTDIR}/mountmap"
 
 RED="\e[2;31m"
@@ -19,23 +19,17 @@ GREEN="\e[2;32m"
 YELLOW="\e[2;33m"
 NORMAL="\e[0m"
 
+HOSTNAME=$(hostname)
+
 _log()
 {
-    echoarg=""
-
-    # We only support -n argument to echo.
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
-
     color=$1
     msg=$2
 
-    echo $echoarg -e "${color}${msg}${NORMAL}"
+    echo -e "${color}${msg}${NORMAL}"
     (
         flock -e 999
-        echo $echoarg -e "$(date -u) $(hostname) $$: ${color}${msg}${NORMAL}" >> $LOGFILE
+        echo -e "$(date -u +"%a %b %d %G %T.%3N") $HOSTNAME $$: ${color}${msg}${NORMAL}" >> $LOGFILE
     ) 999<$LOGFILE
 }
 
@@ -44,13 +38,8 @@ _log()
 #
 pecho()
 {
-    echoarg=""
     color=$NORMAL
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
-    _log $echoarg $color "${*}"
+    _log $color "${*}"
 }
 
 #
@@ -58,13 +47,8 @@ pecho()
 #
 secho()
 {
-    echoarg=""
     color=$GREEN
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
-    _log $echoarg $color "${*}"
+    _log $color "${*}"
 }
 
 #
@@ -72,13 +56,8 @@ secho()
 #
 wecho()
 {
-    echoarg=""
     color=$YELLOW
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
-    _log $echoarg $color "${*}"
+    _log $color "${*}"
 }
 
 #
@@ -86,13 +65,8 @@ wecho()
 #
 eecho()
 {
-    echoarg=""
     color=$RED
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
-    _log $echoarg $color "${*}"
+    _log $color "${*}"
 }
 
 #
@@ -100,91 +74,135 @@ eecho()
 #
 vecho()
 {
-    echoarg=""
     color=$NORMAL
-    if [ "$1" == "-n" ]; then
-        echoarg="-n"
-        shift
-    fi
 
     # Unless AZNFS_VERBOSE flag is set, do not echo to console.
     if [ -z "$AZNFS_VERBOSE" -o "$AZNFS_VERBOSE" == "0" ]; then
         (
             flock -e 999
-            echo $echoarg -e "$(date -u) $(hostname) $$: ${color}${*}${NORMAL}" >> $LOGFILE
+            echo -e "$(date -u +"%a %b %d %G %T.%3N") $HOSTNAME $$: ${color}${*}${NORMAL}" >> $LOGFILE
         ) 999<$LOGFILE
 
         return
     fi
 
-    _log $echoarg $color "${*}"
+    _log $color "${*}"
 }
 
-# 
-# Check if the given string is a valid IPv4 address. 
-# 
-is_valid_ipv4_address() 
-{ 
-    #
-    # ip route allows 10.10 as a valid address and treats it as 10.10.0.0, so 
-    # we need the first coarse filter too.
-    #
-    [[ $1 =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] && 
-    ip -4 route save match $1 > /dev/null 2>&1 
+#
+# Check if the given string is a valid IPv4 address.
+#
+is_valid_ipv4_address()
+{
+    [[ "$1" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] &&
+    [ ${BASH_REMATCH[1]} -le 255 ] &&
+    [ ${BASH_REMATCH[2]} -le 255 ] &&
+    [ ${BASH_REMATCH[3]} -le 255 ] &&
+    [ ${BASH_REMATCH[4]} -le 255 ]
 }
 
 #
 # Check if the given string is a valid IPv4 prefix.
 # 10, 10.10, 10.10.10, 10.10.10.10 are valid prefixes, while
-# 1000, 10.256, 10. are not valid prefixes. 
+# 1000, 10.256, 10. are not valid prefixes.
 #
 is_valid_ipv4_prefix()
 {
     ip -4 route get fibmatch $1 > /dev/null 2>&1
 }
 
-# 
+#
+# Check if a given TCP port is reachable. Uses a 3 secs timeout to bail out if address/port is not reachable.
+#
+is_ip_port_reachable()
+{
+    local ip=$1;
+    local port=$2;
+
+    # 3 secs timeout should be good.
+    nc -w 3 -z $ip $port > /dev/null 2>&1
+}
+
+#
 # Blob fqdn to IPv4 adddress.
 # Caller must make sure that it is called only for hostname and not IP address.
-# 
+#
 resolve_ipv4()
-{ 
+{
+    vecho "Inside resolve_ipv4"
     local hname="$1"
 
-    # Resolve hostname to IPv4 address.
-    host_op=$(host -4 -t A "$hname" | sort) 
-    if [ $? -ne 0 ]; then
-        eecho "Bad Blob FQDN: $hname" 
-        return 1 
-    fi 
+    # Some retries for resilience.
+    for((i=0;i<3;i++)) {
+        # Resolve hostname to IPv4 address.
+        host_op=$(host -4 -t A "$hname")
+        if [ $? -ne 0 ]; then
+            eecho "Failed to resolve ${hname}!"
+            # Exhausted retries?
+            if [ $i -eq 3 ]; then
+                return 1
+            fi
+            # Mostly some transient issue, retry after some sleep.
+            sleep 5
+            continue
+        fi
 
-    # 
-    # For ZRS accounts, we will get 3 IP addresses whose order keeps changing.
-    # We sort the output of host so that we always look at the same address.
-    # 
-    local cnt_ip=$(echo "$host_op" | grep " has address " | awk '{print $4}' | head -n1 | wc -l) 
+        vecho "After host"
+        #
+        # For ZRS accounts, we will get 3 IP addresses whose order keeps changing.
+        # We sort the output of host so that we always look at the same address,
+        # also we shuffle it so that different clients balance out across different
+        # zones.
+        #
+        ipv4_addr_all=$(echo "$host_op" | grep " has address " | awk '{print $4}' |\
+                        sort | shuf --random-source=/etc/machine-id)
 
-    if [ $cnt_ip -ne 1 ]; then 
-        eecho "host returned $cnt_ip address(es) for ${hname}, expected 1!" 
-        return 1 
+        cnt_ip=$(echo "$ipv4_addr_all" | wc -l)
+        vecho "After cnt_ip"
+
+        if [ $cnt_ip -eq 0 ]; then
+            eecho "host returned 0 address for ${hname}, expected one or more! [$host_op]"
+            # Exhausted retries?
+            if [ $i -eq 3 ]; then
+                return 1
+            fi
+            # Mostly some transient issue, retry after some sleep.
+            sleep 5
+            continue
+        fi
+
+        break
+    }
+
+    # Use first address from the above curated list.
+    ipv4_addr=$(echo "$ipv4_addr_all" | head -n1)
+    vecho "After ipv4_addr"
+
+    # For ZRS we need to use the first reachable IP.
+    if [ $cnt_ip -ne 1 ]; then
+        for((i=1;i<=$cnt_ip;i++)) {
+            ipv4_addr=$(echo "$ipv4_addr_all" | tail -n +$i | head -n1)
+            if is_ip_port_reachable $ipv4_addr 2048; then
+                break
+            fi
+        }
     fi
 
-    local ipv4_addr=$(echo "$host_op" | grep " has address " | head -n1 | awk '{print $4}') 
-    
-    if ! is_valid_ipv4_address "$ipv4_addr"; then 
-        eecho "[FATAL] host returned bad IPv4 address $ipv4_addr for hostname ${hname}!" 
-        return 1 
-    fi 
+    if ! is_valid_ipv4_address "$ipv4_addr"; then
+        eecho "[FATAL] host returned bad IPv4 address $ipv4_addr for hostname ${hname}!"
+        return 1
+    fi
 
-    echo $ipv4_addr 
-    return 0 
+    vecho "After is_valid_ipv4_address"
+    echo $ipv4_addr
+    return 0
 }
 
 #
 # Function to check if an IP is private.
 #
-is_private_ip() 
-{ 
+is_private_ip()
+{
     local ip=$1
 
     if ! is_valid_ipv4_address $ip; then
@@ -195,42 +213,101 @@ is_private_ip()
     # Check if the IP belongs to the private IP range (10.0.0.0/8,
     # 172.16.0.0/12, or 192.168.0.0/16).f
     #
-    [[ $ip =~ ^10\..* ]] || 
-    [[ $ip =~ ^172\.(1[6-9]|2[0-9]|3[0-1])\..* ]] || 
+    [[ $ip =~ ^10\..* ]] ||
+    [[ $ip =~ ^172\.(1[6-9]|2[0-9]|3[0-1])\..* ]] ||
     [[ $ip =~ ^192\.168\..* ]]
 }
 
 #
-# MOUNTMAP is accessed by both mount.aznfs and aznfswatchdog service. Update it 
+# Mount helper must call this function to grab a timed lease on all MOUNTMAP
+# entries. It should do this if it decides to use any of the entries. Once
+# this is called aznfswatchdog is guaranteed to not delete any MOUNTMAP till
+# the next 5 minutes.
+#
+# Must be called with MOUNTMAP lock held.
+#
+touch_mountmap()
+{
+    chattr -f -i $MOUNTMAP
+    touch $MOUNTMAP
+    if [ $? -ne 0 ]; then
+        chattr -f +i $MOUNTMAP
+        eecho "Failed to touch ${MOUNTMAP}!"
+        return 1
+    fi
+    chattr -f +i $MOUNTMAP
+}
+
+#
+# MOUNTMAP is accessed by both mount.aznfs and aznfswatchdog service. Update it
 # only after taking exclusive lock.
 #
 # Add entry to $MOUNTMAP in case of a new mount or IP change for blob FQDN.
 #
+# This also ensures that the corresponding DNAT rule is created so that MOUNTMAP
+# entry and DNAT rule are always in sync.
+#
+ensure_mountmap_exist_nolock()
+{
+    IFS=" " read l_host l_ip l_nfsip l_pid <<< "$1"
+    if ! ensure_iptable_entry $l_ip $l_nfsip; then
+        eecho "[$1] failed to add to ${MOUNTMAP}!"
+        return 1
+    fi
+
+    egrep -q "^${1}$" $MOUNTMAP
+    if [ $? -ne 0 ]; then
+        chattr -f -i $MOUNTMAP
+        echo "$1" >> $MOUNTMAP
+        if [ $? -ne 0 ]; then
+            chattr -f +i $MOUNTMAP
+            eecho "[$1] failed to add to ${MOUNTMAP}!"
+            # Could not add MOUNTMAP entry, delete the DNAT rule added above.
+            delete_iptable_entry $l_ip $l_nfsip
+            return 1
+        fi
+        chattr -f +i $MOUNTMAP
+    else
+        pecho "[$1] already exists in ${MOUNTMAP}."
+    fi
+}
+
 ensure_mountmap_exist()
 {
     (
         flock -e 999
-        egrep -q "^${1}$" $MOUNTMAP
-        if [ $? -ne 0 ]; then
-            chattr -f -i $MOUNTMAP
-            echo "$1" >> $MOUNTMAP
-            if [ $? -ne 0 ]; then
-                chattr -f +i $MOUNTMAP
-                eecho "[$1] failed to add to ${MOUNTMAP}!"
-                return 1
-            fi
-            chattr -f +i $MOUNTMAP
-        else
-            pecho "[$1] already exists in ${MOUNTMAP}."
-        fi 
+        ensure_mountmap_exist_nolock "$1"
+        return $?
     ) 999<$MOUNTMAP
 }
 
 #
-# Delete entry from $MOUNTMAP in case of unmount or IP change for blob FQDN.
+# Delete entry from $MOUNTMAP and also the corresponding iptable rule.
 #
 ensure_mountmap_not_exist()
 {
+    #
+    # If user wants to delete the entry only if MOUNTMAP has not changed since
+    # he looked up, honour that.
+    #
+    local ifmatch="$2"
+    if [ -n "$ifmatch" ]; then
+        local mtime=$(stat -c%Y $MOUNTMAP)
+        if [ "$mtime" != "$ifmatch" ]; then
+            eecho "[$1] Refusing to remove from ${MOUNTMAP} as $mtime != $ifmatch!"
+            return 1
+        fi
+    fi
+
+    # Delete iptable rule corresponding to the outgoing MOUNTMAP entry.
+    IFS=" " read l_host l_ip l_nfsip <<< "$1"
+    if [ -n "$l_host" -a -n "$l_ip" -a -n "$l_nfsip" ]; then
+        if ! ensure_iptable_entry_not_exist $l_ip $l_nfsip; then
+            eecho "[$1] Refusing to remove from ${MOUNTMAP} as iptable entry could not be deleted!"
+            return 1
+        fi
+    fi
+
     (
         flock -e 999
         chattr -f -i $MOUNTMAP
@@ -238,10 +315,54 @@ ensure_mountmap_not_exist()
         if [ $? -ne 0 ]; then
             chattr -f +i $MOUNTMAP
             eecho "[$1] failed to remove from ${MOUNTMAP}!"
+            # Reinstate DNAT rule deleted above.
+            ensure_iptable_entry $l_ip $l_nfsip
             return 1
         fi
         chattr -f +i $MOUNTMAP
     ) 999<$MOUNTMAP
+}
+
+#
+# Replace a mountmap entry with a new one.
+# This will also update the iptable DNAT rules accordingly, deleting DNAT rule
+# corresponding to old entry and adding the DNAT rule corresponding to the new
+# entry.
+#
+update_mountmap_entry()
+{
+    local old=$1
+    local new=$2
+
+    IFS=" " read l_host l_ip l_nfsip_old <<< "$old"
+    if [ -n "$l_host" -a -n "$l_ip" -a -n "$l_nfsip_old" ]; then
+        if ! ensure_iptable_entry_not_exist $l_ip $l_nfsip_old; then
+            eecho "[$old] Refusing to remove from ${MOUNTMAP} as old iptable entry could not be deleted!"
+            return 1
+        fi
+    fi
+
+    IFS=" " read l_host l_ip l_nfsip_new <<< "$new"
+    if [ -n "$l_host" -a -n "$l_ip" -a -n "$l_nfsip_new" ]; then
+        if ! ensure_iptable_entry $l_ip $l_nfsip_new; then
+            eecho "[$new] Refusing to remove from ${MOUNTMAP} as new iptable entry could not be added!"
+            # Roll back.
+            ensure_iptable_entry $l_ip $l_nfsip_old
+            return 1
+        fi
+    fi
+
+    chattr -f -i $MOUNTMAP
+    sed -i "s%^${old}$%${new}%g" $MOUNTMAP
+    if [ $? -ne 0 ]; then
+        chattr -f +i $MOUNTMAP
+        eecho "[$old -> $new] failed to update ${MOUNTMAP}!"
+        # Roll back.
+        ensure_iptable_entry_not_exist $l_ip $l_nfsip_new
+        ensure_iptable_entry $l_ip $l_nfsip_old
+        return 1
+    fi
+    chattr -f +i $MOUNTMAP
 }
 
 #
@@ -286,6 +407,43 @@ delete_iptable_entry()
 }
 
 #
+# Ensure given DNAT rule exists, if not it creates it else silently exits.
+#
+ensure_iptable_entry()
+{
+    iptables -w 60 -t nat -C OUTPUT -p tcp -d "$1" -j DNAT --to-destination "$2" 2> /dev/null
+    if [ $? -ne 0 ]; then
+        iptables -w 60 -t nat -I OUTPUT -p tcp -d "$1" -j DNAT --to-destination "$2"
+        if [ $? -ne 0 ]; then
+            eecho "Failed to add DNAT rule [$1 -> $2]!"
+            return 1
+        fi
+    fi
+}
+
+#
+# Ensure given DNAT rule is deleted, silently exits if the rule doesn't exist.
+# Also removes the corresponding entry from conntrack.
+#
+ensure_iptable_entry_not_exist()
+{
+    iptables -w 60 -t nat -C OUTPUT -p tcp -d "$1" -j DNAT --to-destination "$2" 2> /dev/null
+    if [ $? -eq 0 ]; then
+        iptables -w 60 -t nat -D OUTPUT -p tcp -d "$1" -j DNAT --to-destination "$2"
+        if [ $? -ne 0 ]; then
+            eecho "Failed to delete DNAT rule [$1 -> $2]!"
+            return 1
+        fi
+
+        # Ignore status of conntrack because entry may not exist (timed out).
+        output=$(conntrack -D conntrack -p tcp -d "$1" -r "$2" 2>&1)
+        if [ $? -ne 0 ]; then
+            vecho "$output"
+        fi
+    fi
+}
+
+#
 # Verify if the mountmap entry is present but corresponding DNAT rule does not
 # exist. Add it to avoid IOps failure.
 #
@@ -299,26 +457,6 @@ verify_iptable_entry()
             eecho "Failed to add DNAT rule [$1 -> $2]!"
             return 1
         fi
-    fi
-}
-
-#
-# Must be called only when $l_ip:$l_dir is mounted.
-#
-unmount_and_delete_iptable_entry()
-{
-    local l_ip=$1
-    local l_dir=$2
-    local l_nfsip=$3
-
-    pecho "Unmounting [${l_ip}:${l_dir}]."
-    if umount -lf "${l_ip}:${l_dir}"; then
-        # Clear the DNAT rule.
-        if ! delete_iptable_entry "$l_ip" "$l_nfsip"; then
-            eecho "iptables failed to delete DNAT rule [$l_ip -> $l_nfsip]!"
-        fi
-    else
-        eecho "Failed to unmount [${l_ip}:${l_dir}]!"
     fi
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -141,6 +141,15 @@ resolve_ipv4()
         # Resolve hostname to IPv4 address.
         host_op=$(host -4 -t A "$hname" 2>&1)
         if [ $? -ne 0 ]; then
+            #
+            # Special case of failure to indicate that the fqdn doesn't exist.
+            # We convey it to our caller using the special o/p "NXDOMAIN".
+            #
+            if [[ "$host_op" =~ .*NXDOMAIN.* ]]; then
+                echo "NXDOMAIN"
+                return 1
+            fi
+
             vecho "Failed to resolve ${hname}: $host_op!"
             # Exhausted retries?
             if [ $i -eq $RETRIES ]; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -249,7 +249,7 @@ touch_mountmap()
 #
 ensure_mountmap_exist_nolock()
 {
-    IFS=" " read l_host l_ip l_nfsip l_pid <<< "$1"
+    IFS=" " read l_host l_ip l_nfsip <<< "$1"
     if ! ensure_iptable_entry $l_ip $l_nfsip; then
         eecho "[$1] failed to add to ${MOUNTMAP}!"
         return 1

--- a/packaging/aznfs/DEBIAN/postinst
+++ b/packaging/aznfs/DEBIAN/postinst
@@ -17,6 +17,21 @@ chmod 0644 /opt/microsoft/aznfs/common.sh
 # Set suid bit for mount.aznfs to allow mount for non-super user.
 chmod 4755 /sbin/mount.aznfs
 
+# Create a random byte source for deterministic shuffling of IP addresses.
+set +e
+dd if=/dev/urandom of=/opt/microsoft/aznfs/randbytes bs=256 count=1
+if [ ! -s /opt/microsoft/aznfs/randbytes ]; then
+	uuidgen > /opt/microsoft/aznfs/randbytes
+fi
+if [ ! -s /opt/microsoft/aznfs/randbytes ]; then
+	date | md5sum | awk '{print $1}' > /opt/microsoft/aznfs/randbytes
+fi
+if [ ! -s /opt/microsoft/aznfs/randbytes ]; then
+	date > /opt/microsoft/aznfs/randbytes
+fi
+chattr +i /opt/microsoft/aznfs/randbytes
+set -e
+
 # Start aznfswatchdog service.
 systemctl daemon-reload
 systemctl enable aznfswatchdog

--- a/packaging/aznfs/DEBIAN/postrm
+++ b/packaging/aznfs/DEBIAN/postrm
@@ -6,6 +6,7 @@
 # --------------------------------------------------------------------------------------------
 
 if [ "$1" == 'remove' -o "$1" == 'purge' ]; then
-	chattr -if /opt/microsoft/aznfs/mountmap
+	chattr -f -i /opt/microsoft/aznfs/mountmap
+	chattr -f -i /opt/microsoft/aznfs/randbytes
 	rm -rf /opt/microsoft/aznfs
 fi

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -29,7 +29,7 @@ vecho "Starting aznfswatchdog..."
 
 # Dump NAT table once on startup in case we have reported conflicts.
 vecho "NAT table:\n$(iptables-save -t nat)"
-connntrack -L > /dev/null
+conntrack -L > /dev/null
 
 # connntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
 connntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -183,9 +183,18 @@ while :; do
 
         # If we fail to resolve the host name, try next time.
         if [ $? -ne 0 ]; then
-            echo "$new_ip"
-            eecho "resolve_ipv4($l_host) failed!"
-            next_ip_change_detection_epoch=$(date +%s)
+            #
+            # If account is deleted then we need to delete the MOUNTMAP entry along
+            # with the proxy iptable entry created for that account.
+            # Note that we don't delete if the MOUNTMAP was changed recently since
+            # the account may have been re-created after the dns lookup failure.
+            #
+            if [ "$new_ip" == "NXDOMAIN" ]; then
+                pecho "Account corresponding to $l_host seems to have been deleted!"
+                ensure_mountmap_not_exist "$line" "$mtime_mountmap"
+            else
+                eecho "resolve_ipv4($l_host) failed: $new_ip"
+            fi
             continue
         fi
 

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -31,10 +31,10 @@ vecho "Starting aznfswatchdog..."
 vecho "NAT table:\n$(iptables-save -t nat)"
 conntrack -L > /dev/null
 
-# connntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
-connntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
-if [ $? -eq 0 -a $connntrack_timeo_timew -gt 65 ]; then
-        vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$connntrack_timeo_timew -> 65]"
+# conntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
+conntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
+if [ $? -eq 0 -a $conntrack_timeo_timew -gt 65 ]; then
+        vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$conntrack_timeo_timew -> 65]"
         echo 65 > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
 fi
 

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -4,21 +4,39 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
- 
+
 #
 # How often does the watchdog look for unmounts and/or IP address changes for
-# Blob endpoints. 
+# Blob endpoints.
 #
 MONITOR_INTERVAL_SECS=5
+
+# How often do we check for change in FQDN->IP?
 IP_CHANGE_DETECTION_FREQUENCY=60
+
+#
+# Remove unmounted entries only if MOUNTMAP has not been changed till MONITOR_INTERVAL_SECS seconds.
+# Don't set it below 3 minutes.
+#
+MOUNTMAP_INACTIVITY_SECS=300
+
 next_ip_change_detection_epoch=0
 
 # Load common aznfs helpers.
 . /opt/microsoft/aznfs/common.sh
 
-vecho "aznfswatchdog has started."
+vecho "Starting aznfswatchdog..."
 
-declare -A is_pid_entry_checked
+# Dump NAT table once on startup in case we have reported conflicts.
+vecho "NAT table:\n$(iptables-save -t nat)"
+connntrack -L > /dev/null
+
+# connntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
+connntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
+if [ $? -eq 0 -a $connntrack_timeo_timew -gt 65 ]; then
+        vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$connntrack_timeo_timew -> 65]"
+        echo 65 > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
+fi
 
 if ! chattr -f +i $MOUNTMAP; then
     wecho "chattr does not work for ${MOUNTMAP}!"
@@ -37,31 +55,47 @@ while :; do
     #       iptables. This will be added in subsequent revisions.
     #
 
-    do_ip_change_detection=false
     epoch_now=$(date +%s)
-    if [ $epoch_now -ge $next_ip_change_detection_epoch ]; then
-        do_ip_change_detection=true
-        next_ip_change_detection_epoch=$(expr $(date +%s) + $IP_CHANGE_DETECTION_FREQUENCY)        
-    fi
 
     #
     # Go over all lines in $MOUNTMAP and check them for two things:
-    # 1. Is that entry still mounted, if not remove the entry.
+    # 1. Is that entry still in use by at least one aznfs mount, if not remove the entry.
     # 2. Has the Blob endpoint address changed from what is stored?
-    #    If yes, update DNAT rule to point to the new address.
+    #    If yes, update DNAT rule to point to the new address and update entry accordingly.
     #
     # Sample line in $MOUNTMAP.
-    # account.blob.preprod.core.windows.net:/testaccount/testcontainer 10.100.100.100 52.230.170.200
+    # account.blob.preprod.core.windows.net 10.100.100.100 52.230.170.200
     #
     # where the format is
-    # <blobendpoint>:/account/container LOCAL_IP blobendpoint_ip
-    # 
+    # blobendpoint_fqdn proxy_ip blobendpoint_ip
+    #
+    exec {fd}<$MOUNTMAP
+    flock -e $fd
+    mtime_mountmap=$(stat -c%Y $MOUNTMAP)
     IFS=$'\n' lines=$(cat $MOUNTMAP)
+    flock -u $fd
+    exec {fd}<&-
+
+    do_ip_change_detection=false
+    if [ $epoch_now -ge $next_ip_change_detection_epoch ]; then
+        do_ip_change_detection=true
+        next_ip_change_detection_epoch=$(expr $(date +%s) + $IP_CHANGE_DETECTION_FREQUENCY)
+    fi
+
+    #
+    # Do unmount GC only if MOUNTMAP file is not modified in the last
+    # MOUNTMAP_INACTIVITY_SECS seconds. We don't want to incorrectly delete an
+    # entry while some aznfs mount is ongoing.
+    #
+    do_unmount_gc=false
+    if [ $epoch_now -ge $(expr $mtime_mountmap + $MOUNTMAP_INACTIVITY_SECS) ]; then
+        do_unmount_gc=true
+    fi
 
     #
     # findmnt must be done after reading MOUNTMAP so that if we come accross a
-    # MOUNTMAP entry for which there is no corresponding mount, we know for
-    # sure that it has been unmounted.
+    # MOUNTMAP entry whose proxy_ip is not used by any existing mount, we know
+    # for sure that it's not in use by any mount and can be removed.
     #
     findmnt=$(findmnt --raw --noheading -o MAJ:MIN,FSTYPE,SOURCE,TARGET,OPTIONS -t nfs 2>&1)
 
@@ -70,8 +104,10 @@ while :; do
     # for both exit status and non-empty error o/p.
     #
     if [ $? -ne 0 -a -n "$findmnt" ]; then
-        eecho "findmnt failed!"
         eecho "${findmnt}."
+        eecho "[FATAL] findmnt failed unexpectedly!"
+        eecho "[FATAL] Aznfswatchdog service is exiting, will not monitor Azure NFS shares."
+        eecho "[FATAL] Please contact Microsoft support before using any Blob NFS shares."
         # This usually indicates some non-transient issue, bail out.
         exit 1
     fi
@@ -81,14 +117,13 @@ while :; do
             continue
         fi
 
-        l_share=$(echo "$line" | awk '{print $1}')
-        l_host=$(echo "$l_share" | cut -d: -f1)
-        l_dir=$(echo "$l_share" | cut -d: -f2)
-        l_ip=$(echo "$line" | awk '{print $2}')
-        l_nfsip=$(echo "$line" | awk '{print $3}')
-        l_pid=$(echo "$line" | awk '{print $4}')
+        #
+        # MOUNTMAP line is of the form:
+        # account.blob.preprod.core.windows.net <local ip> <public ip> [<PID>]
+        #
+        IFS=" " read l_host l_ip l_nfsip <<< "$line"
 
-        if [ -z "$l_host" -o -z "$l_dir" -o -z "$l_ip" -o -z "$l_nfsip" ]; then
+        if [ -z "$l_host" -o -z "$l_ip" -o -z "$l_nfsip" ]; then
             wecho "[FATAL] Deleting invalid line in $MOUNTMAP: [$line]!"
             ensure_mountmap_not_exist "$line"
             continue
@@ -109,79 +144,19 @@ while :; do
         fi
 
         #
-        # If mount.aznfs program is killed in a state where IPtable entry is
-        # added, entry with PID is added, mount has happened but the final 
-        # entry is not added, aznfswatchdog should fix it by removing the entry
-        # with PID and by adding original entry.
+        # Delete entry from MOUNTMAP if there are no mounted shares on that host.
+        # As long as we have at least one mount using the MOUNTMAP entry, we leave
+        # it around.
         #
-        fixup_mountmap=false
-
-        #
-        # This entry was added by get_free_local_ip() call in mount.aznfs to
-        # to ensure two parallel mount requests do not get same local ip. Skip
-        # this entry if PID is active.
-        #
-        if [ -n "$l_pid" ]; then
-            #
-            # If the line was deleted by the mount.aznfs after we read it from
-            # MOUNTMAP and till we reached this point, ignore this line.
-            #
-            if ! egrep -q "^${line}$" $MOUNTMAP; then
+        if ! echo "$findmnt" | grep -q " nfs ${l_ip}:"; then
+            if $do_unmount_gc; then
+                pecho "No mounted shares for host $l_host, deleting from ${MOUNTMAP} [$line]."
+                ensure_mountmap_not_exist "$line" "$mtime_mountmap"
                 continue
             fi
-
-            #
-            # Do not process the PID entry if the watchdog finds it for the 
-            # first time since the mount.aznfs could still be running. Iterate
-            # through the loop again from the start to avoid any race condition.
-            #
-            epoch_now=$(date +%s)
-            if [ ! -v is_pid_entry_checked[$l_pid] ] || [ ${is_pid_entry_checked[$l_pid]} -le $(expr $epoch_now - 300) ]; then
-                is_pid_entry_checked[$l_pid]=$epoch_now
-                break
-            fi
-
-            unset is_pid_entry_checked[$l_pid]
-
-            if ! ps -p $l_pid > /dev/null; then
-                wecho "[FATAL] PID ($l_pid) is not active!"
-                ensure_mountmap_not_exist "$line"
-                fixup_mountmap=true
-            else
-                continue
-            fi
-        fi
-
-        #
-        # Local share name. Note that we mount the local IP and not the actual
-        # Blob endpoint IP and map local IP to actual Blob endpoint IP using
-        # DNAT rule.
-        #
-        m_share="$l_ip:$l_dir"
-
-        #
-        # Delete entry from MOUNTMAP if share is unmounted.
-        # TODO: What if user unmounts and mounts before MONITOR_INTERVAL_SECS secs?
-        #
-        if ! echo "$findmnt" | grep " nfs $m_share " > /dev/null; then
-            # delete the line from MOUNTMAP file.
-            pecho "Deleting unmounted share from ${MOUNTMAP} [$line]."
-
-            delete_iptable_entry "$l_ip" "$l_nfsip"
-
-            #
-            # Ignore the status of delete_iptable_entry and fallthrough to
-            # delete the mountmap entry. The iptable entry will be leaked but
-            # not deleting mountmap entry might cause this situation to occur 
-            # again and again and flood the logs.
-            #
-            
-            ensure_mountmap_not_exist "$line"
-            continue
         else
-            
             #
-            # Verify that iptable entry should be present for corresponding 
+            # Verify that iptable entry should be present for corresponding
             # MOUNTMAP entry if the share is not unmounted.
             #
             # Note: This is extra protection in case user flushes the iptable
@@ -189,23 +164,6 @@ while :; do
             #       required normally.
             #
             verify_iptable_entry "$l_ip" "$l_nfsip"
-
-            if $fixup_mountmap; then
-                if ! ensure_mountmap_exist "$l_host:$l_dir $l_ip $l_nfsip"; then
-
-                    #
-                    # Since we do not have the entry in MOUNTMAP to track the
-                    # mount, safe to unmount it. It is better to unmount it now
-                    # than leaving it around which can render it unusable at
-                    # an arbitrary point in future when the account is
-                    # migrated. 
-                    #
-                    # Note: User may already be using the mount and we will
-                    #       unmount under him.
-                    #
-                    unmount_and_delete_iptable_entry "$l_ip" "$l_dir" "$l_nfsip"
-                fi
-            fi
         fi
 
         #
@@ -226,6 +184,7 @@ while :; do
         if [ $? -ne 0 ]; then
             echo "$new_ip"
             eecho "resolve_ipv4($l_host) failed!"
+            next_ip_change_detection_epoch=$(date +%s)
             continue
         fi
 
@@ -233,54 +192,14 @@ while :; do
         # If the IP changed for the Blob endpoint, we need to update the DNAT rule.
         # This will take care of migration/failover causing the Blob endpoint IP to change.
         #
-        # TODO: Make this less frequent than the unmount check.
-        #
-        # echo "$l_host: new_ip=$new_ip, l_nfsip=$l_nfsip"
-        #
         if [ "$new_ip" != "$l_nfsip" ]; then
             pecho "IP for $l_host changed [$l_nfsip -> $new_ip]."
 
-            # Delete old DNAT rule and the conntrack entry to stop current active connections too.
-            delete_iptable_entry "$l_ip" "$l_nfsip"
-
-            #
-            # Ignore the status of delete_iptable_entry and fallthrough to
-            # delete the mountmap entry. The iptable entry will be leaked but
-            # not deleting mountmap entry might cause this situation to occur 
-            # again and again and flood the logs.
-            #
-
-            # Add DNAT rule for forwarding local ip traffic to the new blob endpoint IP address.
-            if add_iptable_entry "$l_ip" "$new_ip"; then
-                
-                #
-                # Add new entry in MOUNTMAP.
-                # We add the new entry before deleting the old one so that already 
-                # used local_ip is not used by any other new aznfs mount.
-                # 
-                if ! ensure_mountmap_exist "$l_host:$l_dir $l_ip $new_ip"; then
-                    eecho "This can likely be due to some unexpected manipulation of the ${MOUNTMAP} file."
-                    eecho "Aznfswatchdog service exiting, will not monitor Azure NFS shares for change in endpoint IP."
-                    eecho "Please contact Microsoft support."
-                    exit 0
-                fi
-
-                # Delete the entry from MOUNTMAP.
-                if ! ensure_mountmap_not_exist "$line"; then
-                    eecho "This can likely be due to some unexpected manipulation of the ${MOUNTMAP} file."
-                    eecho "Aznfswatchdog service exiting, will not monitor Azure NFS shares for change in endpoint IP."
-                    eecho "Please contact Microsoft support."
-
-                    #
-                    # Bail out in this case because if we keep checking for this
-                    # entry, it will flood the logs and iptables. 
-                    #
-                    exit 0
-                fi
-            else
+            # This will update DNAT rule as well.
+            if ! update_mountmap_entry "$line" "$l_host $l_ip $new_ip"; then
                 eecho "Will reattempt the operation in next iteration."
             fi
-        fi 
+        fi
     done
 
 done

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -148,7 +148,7 @@ while :; do
         # As long as we have at least one mount using the MOUNTMAP entry, we leave
         # it around.
         #
-        if ! echo "$findmnt" | grep -q " nfs ${l_ip}:"; then
+        if ! echo "$findmnt" | grep " nfs ${l_ip}:" >/dev/null; then
             if $do_unmount_gc; then
                 pecho "No mounted shares for host $l_host, deleting from ${MOUNTMAP} [$line]."
                 ensure_mountmap_not_exist "$line" "$mtime_mountmap"

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -151,6 +151,7 @@ while :; do
         if ! echo "$findmnt" | grep " nfs ${l_ip}:" >/dev/null; then
             if $do_unmount_gc; then
                 pecho "No mounted shares for host $l_host, deleting from ${MOUNTMAP} [$line]."
+                # Delete IFF mountmap is not changed since we read it above.
                 ensure_mountmap_not_exist "$line" "$mtime_mountmap"
                 continue
             fi

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -458,11 +458,9 @@ ensure_aznfswatchdog()
 vecho "Got arguments: [$*]"
 
 # Check if aznfswatchdog service is running.
-vecho "Before ensure_aznfswatchdog"
 if ! ensure_aznfswatchdog; then
     exit 1
 fi
-vecho "After ensure_aznfswatchdog"
 
 # MOUNTMAP file must have been created by aznfswatchdog service.
 if [ ! -f "$MOUNTMAP" ]; then
@@ -484,7 +482,6 @@ if ! is_valid_blob_fqdn "$nfs_host"; then
     exit 1
 fi
 
-vecho "Resolving $nfs_host"
 nfs_ip=$(resolve_ipv4 "$nfs_host")
 if [ $? -ne 0 ]; then
     echo "$nfs_ip"
@@ -510,11 +507,8 @@ mount_point="$2"
 OPTIONS=
 MOUNT_OPTIONS=
 
-vecho "Before parse_arguments"
 parse_arguments $*
-vecho "After parse_arguments"
 
-vecho "Before get_local_ip_for_fqdn"
 #
 # Get proxy IP to use for this mount.
 # It'll ensure an appropriate entry is added to MOUNTMAP if not already added,
@@ -526,7 +520,6 @@ get_local_ip_for_fqdn $nfs_host
 ret=$?
 flock -u $fd
 exec {fd}<&-
-vecho "After get_local_ip_for_fqdn"
 
 if [ $ret -ne 0 ]; then
     if [ -z "$AZNFS_IP_PREFIXES" ]; then

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -488,7 +488,6 @@ if [ $? -ne 0 ]; then
     eecho "Cannot resolve IP address for ${nfs_host}!"
     exit 1
 fi
-vecho "Resolved $nfs_host -> $nfs_ip"
 
 nfs_dir=$(get_dir_from_share "$1")
 if [ $? -ne 0 ]; then

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -535,6 +535,16 @@ MOUNT_OPTIONS=
 parse_arguments $*
 
 #
+# Check azure nconnect flag.
+#
+if [ "$AZNFS_CHECK_AZURE_NCONNECT" == "1" ]; then
+    if ! check_nconnect; then
+        eecho "Mount failed!"
+        exit 1
+    fi
+fi
+
+#
 # Get proxy IP to use for this mount.
 # It'll ensure an appropriate entry is added to MOUNTMAP if not already added,
 # and an appropriate iptable DNAT rule is added.
@@ -558,16 +568,6 @@ if [ $ret -ne 0 ]; then
 fi
 
 vecho "nfs_host=[$nfs_host], nfs_ip=[$nfs_ip], nfs_dir=[$nfs_dir], mount_point=[$mount_point], options=[$OPTIONS], mount_options=[$MOUNT_OPTIONS], local_ip=[$LOCAL_IP]."
-
-#
-# Check azure nconnect flag.
-#
-if [ "$AZNFS_CHECK_AZURE_NCONNECT" == "1" ]; then
-    if ! check_nconnect; then
-        eecho "Mount failed!"
-        exit 1
-    fi
-fi
 
 #
 # AZNFS uses fixed port 2048 for mount and nfs.

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -368,8 +368,7 @@ search_free_local_ip_with_prefix()
 
             is_ip_used_by_aznfs=$(echo "$used_local_ips_with_same_prefix" | grep "^${local_ip}$")
             if [ -n "$is_ip_used_by_aznfs" ]; then
-                # Avoid excessive logs.
-                # vecho "$local_ip is in use by aznfs!"
+                vecho "$local_ip is in use by aznfs!"
                 continue
             fi
 
@@ -623,7 +622,7 @@ if [ "$AZNFS_FIX_MOUNT_OPTIONS" == "1" ]; then
 fi
 
 #
-# Get proxy IP to use for this mount.
+# Get proxy IP to use for this nfs_ip.
 # It'll ensure an appropriate entry is added to MOUNTMAP if not already added,
 # and an appropriate iptable DNAT rule is added.
 #

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -23,7 +23,7 @@ AZNFS_PORT="${AZNFS_PORT:-2048}"
 # Default to checking azure nconnect support.
 AZNFS_CHECK_AZURE_NCONNECT="${AZNFS_CHECK_AZURE_NCONNECT:-1}"
 
-# Default to fixing mount options passed in to help the users.
+# Default to fixing mount options passed in to help the user.
 AZNFS_FIX_MOUNT_OPTIONS="${AZNFS_FIX_MOUNT_OPTIONS:-1}"
 
 #
@@ -660,6 +660,7 @@ if [ -z "$AZNFS_PMAP_PROBE" -o "$AZNFS_PMAP_PROBE" == "0" ]; then
     if ! [[ "$MOUNT_OPTIONS" =~ $matchstr ]]; then
         MOUNT_OPTIONS="$MOUNT_OPTIONS,mountport=$AZNFS_PORT"
     fi
+    MOUNT_OPTIONS=$(echo "$MOUNT_OPTIONS" | sed "s/^,//g")
 fi
 
 # Do the actual mount.


### PR DESCRIPTION
…ount.

This is very critical change for stability and robustness. It makes many fundamental changes:

1. Use single proxy IP per account irrespective of how many mounts on that account are there from that client, all use the same proxy IP. This makes is analogous to how Linux behaves so many surprises will go away. One of the major reasons for this is to prevent issues with conntrack. If we use one proxy IP per mount then DNAT does not work well since Linux client can use the same port for two different IPs. These clash on the outgoing leg of the DNAT. This cuts down the iptable and mountmap size drastically and helps robustness.
2. Another thing that helps robustness is that we no don't rush to clean up unmounted entries in mountmap and iptables. One of the drivers for that is #1 above since now there are not too many entries in these tables. This simplies the code a lot with all the PID tagged entry logic removed.
3. Now we ensure that mountmap and iptables are always in sync right from the point the mountmap entry is created. When mountmap entry is created iptable entry is also created atomically and when mountmap entry is deleted the iptable entty is also deleted, so at all time they are in sync which simplifies the logic and improves robustness.
4. Many perf improvements by using bash builtins in place of cut/grep/ip tools.
5. resolve_ipv4 is improved for robustness and ZRS support.
6. Logging function simplified.
7. Perf improvement by avoiding portmap calls in the common case.