### PR TITLE
Allow /etc/fstab entries to auto-mount after reboot

### DIFF
--- a/src/aznfswatchdog.service
+++ b/src/aznfswatchdog.service
@@ -18,4 +18,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=nfs-client.target


### PR DESCRIPTION
Allow /etc/fstab entries to auto-mount after reboot