### PR TITLE
Added dependency on bash and ps.

### DIFF
--- a/packaging/aznfs/DEBIAN/control
+++ b/packaging/aznfs/DEBIAN/control
@@ -6,4 +6,4 @@ Origin: Microsoft
 Maintainer: Azure Storage XNFSv3 IDC Team <xnfsv3devsidc@microsoft.com>
 Homepage: https://github.com/Azure/AZNFS-mount/blob/main/README.md
 Description: Mount helper program for correctly handling endpoint IP address changes for Azure Blob NFS mounts
-Depends: conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat
+Depends: bash, procps, conntrack, iptables, bind9-host, libcap2, iproute2, util-linux, nfs-common, netcat

--- a/packaging/aznfs/DEBIAN/control
+++ b/packaging/aznfs/DEBIAN/control
@@ -6,4 +6,4 @@ Origin: Microsoft
 Maintainer: Azure Storage XNFSv3 IDC Team <xnfsv3devsidc@microsoft.com>
 Homepage: https://github.com/Azure/AZNFS-mount/blob/main/README.md
 Description: Mount helper program for correctly handling endpoint IP address changes for Azure Blob NFS mounts
-Depends: bash, procps, conntrack, iptables, bind9-host, libcap2, iproute2, util-linux, nfs-common, netcat
+Depends: bash, procps, conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat


### PR DESCRIPTION
Also iproute2 fails to resolve its dependency libcap2 on some systems, so we need to explicitly specify that as a dependency.