### PR TITLE
removing systemctl as dependency

### DIFF
--- a/packaging/aznfs/DEBIAN/control
+++ b/packaging/aznfs/DEBIAN/control
@@ -6,4 +6,4 @@ Origin: Microsoft
 Maintainer: Azure Storage XNFSv3 IDC Team <xnfsv3devsidc@microsoft.com>
 Homepage: https://github.com/Azure/AZNFS-mount/blob/main/README.md
 Description: Mount helper program for correctly handling endpoint IP address changes for Azure Blob NFS mounts
-Depends: bash, procps, systemctl, conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat
+Depends: bash, procps, conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat


### PR DESCRIPTION
When trying to install aznfs-mount with Ubuntu 20.04 with systemctl as a dependency, it gives the error:

The following packages have unmet dependencies:
_**aznfs : Depends: systemctl but it is not going to be installed
E: Unable to correct problems, you have held broken packages.**_

When trying to install systemctl explicitly, it fails with:

The following packages have unmet dependencies:
_**libappstream4 : Depends: libsoup2.4-1 (>= 2.56) but it is not going to be installed
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.**_

Upon verifying, we concluded that systemctl was working fine but while installing it fails.

Eventually, we found out that there were 2 similar systemctl being installed as you can see below (one by default and second which script installs) at different locations which are causing issues.

_**root@vm-1:/home/azureuser# ls -l -i /bin/systemctl /usr/bin/systemctl
1727 -rwxr-xr-x 1 root root 996584 Mar 27 17:54 /bin/systemctl
1727 -rwxr-xr-x 1 root root 996584 Mar 27 17:54 /usr/bin/systemctl**_

