### PR TITLE
Adding double quotes

### DIFF
--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -129,6 +129,8 @@ reconcile_conntrack()
     done
 }
 
+vecho "Starting aznfswatchdog..."
+
 # Detect and log distro and bash version
 if [ -f /etc/centos-release ]; then
     linux_distro=$(cat /etc/centos-release)
@@ -141,8 +143,6 @@ fi
 bash_version=$(bash --version | head -n 1)
 vecho "Linux distribution: $linux_distro"
 vecho "Bash version: $bash_version"
-
-vecho "Starting aznfswatchdog..."
 
 # Dump NAT table once on startup in case we have reported conflicts.
 vecho "NAT table:\n$(iptables-save -t nat)"

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -137,7 +137,7 @@ conntrack -L > /dev/null
 
 # conntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
 conntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
-if [ $? -eq 0 ] && [ "$conntrack_timeo_timew" -gt "$AZNFS_TIMEWAIT_TIMEOUT" ]; then
+if [ $? -eq 0 ] && [ $conntrack_timeo_timew -gt $AZNFS_TIMEWAIT_TIMEOUT ]; then
         vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$conntrack_timeo_timew -> $AZNFS_TIMEWAIT_TIMEOUT]"
         echo $AZNFS_TIMEWAIT_TIMEOUT > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
 fi

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -130,7 +130,9 @@ reconcile_conntrack()
 }
 
 # Detect and log distro and bash version
-if [ -r /etc/os-release ]; then
+if [ -f /etc/centos-release ]; then
+    linux_distro=$(cat /etc/centos-release)
+elif [ -f /etc/os-release ]; then
     linux_distro=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
 else
     linux_distro="Unknown"

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -137,7 +137,7 @@ conntrack -L > /dev/null
 
 # conntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
 conntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
-if [ $? -eq 0 -a $conntrack_timeo_timew -gt $AZNFS_TIMEWAIT_TIMEOUT ]; then
+if [ $? -eq 0 ] && [ "$conntrack_timeo_timew" -gt "$AZNFS_TIMEWAIT_TIMEOUT" ]; then
         vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$conntrack_timeo_timew -> $AZNFS_TIMEWAIT_TIMEOUT]"
         echo $AZNFS_TIMEWAIT_TIMEOUT > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
 fi

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -133,7 +133,7 @@ vecho "Starting aznfswatchdog..."
 
 # Detect and log distro and bash version
 if [ -f /etc/centos-release ]; then
-    linux_distro=$(cat /etc/centos-release)
+    linux_distro=$(cat /etc/centos-release 2>&1)
 elif [ -f /etc/os-release ]; then
     linux_distro=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
 else
@@ -150,7 +150,7 @@ conntrack -L > /dev/null
 
 # conntrack timewait timeout higher than the TCP timewait timeout value isn't very valuable.
 conntrack_timeo_timew=$(cat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait 2>/dev/null)
-if [ $? -eq 0 ] && [ $conntrack_timeo_timew -gt $AZNFS_TIMEWAIT_TIMEOUT ]; then
+if [ $? -eq 0 ] && [ -n "$conntrack_timeo_timew" -a $conntrack_timeo_timew -gt $AZNFS_TIMEWAIT_TIMEOUT ];
         vecho "Changing /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait [$conntrack_timeo_timew -> $AZNFS_TIMEWAIT_TIMEOUT]"
         echo $AZNFS_TIMEWAIT_TIMEOUT > /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_time_wait
 fi

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -129,6 +129,13 @@ reconcile_conntrack()
     done
 }
 
+# Detect and log distro and bash version
+linux_distro=$(lsb_release -d | cut -f 2)
+vecho "Linux distribution: $linux_distro"
+ 
+bash_version=$(bash --version | head -n 1)
+vecho "Bash version: $bash_version"
+
 vecho "Starting aznfswatchdog..."
 
 # Dump NAT table once on startup in case we have reported conflicts.

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -130,10 +130,14 @@ reconcile_conntrack()
 }
 
 # Detect and log distro and bash version
-linux_distro=$(lsb_release -d | cut -f 2)
-vecho "Linux distribution: $linux_distro"
- 
+if [ -r /etc/os-release ]; then
+    linux_distro=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+else
+    linux_distro="Unknown"
+fi
+
 bash_version=$(bash --version | head -n 1)
+vecho "Linux distribution: $linux_distro"
 vecho "Bash version: $bash_version"
 
 vecho "Starting aznfswatchdog..."


### PR DESCRIPTION
Bug on line 140 in aznfswatchdog script: [: too many arguments
_if [ $? -eq 0 -a $conntrack_timeo_timew -gt $AZNFS_TIMEWAIT_TIMEOUT ]; then_

Solution:
Wrap the variable in double quotes, forcing it to stay as one string (therefore one argument).