### PR TITLE
Azure/palashvij/permissionfix

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,6 +16,9 @@ on:
         description: 'Version Name'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   package_mount_helper:
     name: Package and Release Mount Helper ${{ github.event.inputs.versionName }} (Test Release)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
         description: 'Version Name'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   package_mount_helper:
     name: Package and Release Mount Helper ${{ github.event.inputs.versionName }}


### PR DESCRIPTION
Adding a permission's block in the workflow. To comply with Github's new default Security change:

https://docs.opensource.microsoft.com/github/apps/permission-changes/

Read and Write option for workflows from repository settings got disabled and unavailable to change by default:
![image](https://github.com/Azure/AZNFS-mount/assets/139835364/d7d125bb-ec3e-48f1-ae14-acd00eba6df1)
