### PR TITLE
resolve minor number from combined device id retrieved from stat call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
+## [2.0.9]- July 2024
+- [AZNFS-mount #136](https://github.com/Azure/AZNFS-mount/pull/136)
+  (NFSv3) Resolved the minor and major device numbers from the combined device ID received from the stat call to update the read-ahead configuration.
+
+## [2.0.8]- July 2024
+- [AZNFS-mount #134](https://github.com/Azure/AZNFS-mount/pull/134)
+  (NFSv3) Implemented changes to support retry mount and adjusted read-ahead configuration for improved read throughput.
+
+## [2.0.7]- June 2024
+- [AZNFS-mount #122](https://github.com/Azure/AZNFS-mount/pull/122)
+  (NFSv3) Added support for isolated environments in FQDN using the AZURE_ENDPOINT_OVERRIDE environment variable.
+
+## [2.0.6]- June 2024
+- [AZNFS-mount #120](https://github.com/Azure/AZNFS-mount/pull/120)
+  (NFSv3) Enhanced mount script logs to utilize the -v or --verbose option.
+
 ## [2.0.5]- May 2024
 - [AZNFS-mount #117](https://github.com/Azure/AZNFS-mount/pull/117)
-  (NFSv3) Added support to manage and limit the dirty bytes configuration on the user's machine..
+  (NFSv3) Added support to manage and limit the dirty bytes configuration on the user's machine.
 - [AZNFS-mount #116](https://github.com/Azure/AZNFS-mount/pull/116)
   (NFSv3) Added support in mount-helper for AZNFS fingerprinting.
 

--- a/src/nfsv3mountscript.sh
+++ b/src/nfsv3mountscript.sh
@@ -231,9 +231,17 @@ fix_dirty_bytes_config()
 }
 
 # Function to extract minor number from combined device ID.
-get_minor() {
+get_minor()
+{
     local dev_id=$1
     echo $(( (dev_id & 0xff) | ((dev_id >> 12) & ~0xff) ))
+}
+
+# Function to extract major number from combined device ID.
+get_major()
+{
+    local dev_id=$1
+    echo $(( ((dev_id >> 8) & 0xfff) | ((dev_id >> 32) & ~0xfff) ))
 }
 
 #
@@ -248,9 +256,10 @@ fix_read_ahead_config()
         return
     fi
 
-    minor=$(get_minor $block_device_id)
     # Path to the read_ahead_kb file.
-    read_ahead_path="/sys/class/bdi/0:$minor/read_ahead_kb"
+    major=$(get_major $block_device_id)
+    minor=$(get_minor $block_device_id)
+    read_ahead_path="/sys/class/bdi/$major:$minor/read_ahead_kb"
     if [ ! -e "$read_ahead_path" ]; then
         wecho "The path $read_ahead_path does not exist. Cannot set read ahead."
         return

--- a/src/nfsv3mountscript.sh
+++ b/src/nfsv3mountscript.sh
@@ -230,6 +230,12 @@ fix_dirty_bytes_config()
     fi
 }
 
+# Function to extract minor number from combined device ID.
+get_minor() {
+    local dev_id=$1
+    echo $(( (dev_id & 0xff) | ((dev_id >> 12) & ~0xff) ))
+}
+
 #
 # To Improve read ahead size to increase large file read throughput.
 #
@@ -242,8 +248,9 @@ fix_read_ahead_config()
         return
     fi
 
+    minor=$(get_minor $block_device_id)
     # Path to the read_ahead_kb file.
-    read_ahead_path="/sys/class/bdi/0:$block_device_id/read_ahead_kb"
+    read_ahead_path="/sys/class/bdi/0:$minor/read_ahead_kb"
     if [ ! -e "$read_ahead_path" ]; then
         wecho "The path $read_ahead_path does not exist. Cannot set read ahead."
         return


### PR DESCRIPTION
EXAMPLE LOG WITH DEBUG ADDED TO VERIFY IF WORKING CORRECTLY-

Mounting container529 on /mnt/palash529...
Adding nolock mount option!
Adding retrans=6 mount option!
mount.nfs: timeout set for Tue Jul 23 06:18:00 2024
mount.nfs: trying text-based options 'vers=3,proto=tcp,sec=sys,nolock,retrans=6,port=2048,mountport=2048,addr=10.161.100.105'
Mount completed: palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container529 on /mnt/palash529 using proxy IP 10.161.100.105 and endpoint IP 20.60.185.161
Read ahead size for /mnt/palash529 set to 16384 KB! **_[debug]BLOCK ID=2097225, MINOR=585_**
Mounting container530 on /mnt/palash530...
Adding nolock mount option!
Adding retrans=6 mount option!
mount.nfs: timeout set for Tue Jul 23 06:18:00 2024
mount.nfs: trying text-based options 'vers=3,proto=tcp,sec=sys,nolock,retrans=6,port=2048,mountport=2048,addr=10.161.100.105'
Mount completed: palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container530 on /mnt/palash530 using proxy IP 10.161.100.105 and endpoint IP 20.60.185.161
Read ahead size for /mnt/palash530 set to 16384 KB! [**_debug]BLOCK ID=2097226, MINOR=586_**
Mounting container531 on /mnt/palash531...
Adding nolock mount option!
Adding retrans=6 mount option!
