### PR TITLE
[MAIN] Update workflows to produce artifact correctly -source (.zip)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -53,6 +53,7 @@ jobs:
         name: Test Release ${{ github.event.inputs.versionName }}
         prerelease: true
         tag_name: ${{ github.event.inputs.versionName }}
+        target_commitish: ${{ github.sha }}
         files: |
           ${{ github.workspace }}/deb/aznfs-${{ github.event.inputs.versionName }}-1_amd64.deb
           ${{ github.workspace }}/rpm/root/rpmbuild/RPMS/x86_64/aznfs-${{ github.event.inputs.versionName }}-1.x86_64.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       with:
         name: Release ${{ github.event.inputs.versionName }}
         tag_name: ${{ github.event.inputs.versionName }}
+        target_commitish: ${{ github.sha }}
         files: |
           ${{ github.workspace }}/deb/aznfs-${{ github.event.inputs.versionName }}-1_amd64.deb
           ${{ github.workspace }}/rpm/root/rpmbuild/RPMS/x86_64/aznfs-${{ github.event.inputs.versionName }}-1.x86_64.rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.10]- July 2024
+- [AZNFS-mount #138](https://github.com/Azure/AZNFS-mount/pull/138)
+  (NFSv3) Fixed artifacts to correctly reflect the source code from the specified branch instead of the default main branch.
+
 ## [2.0.9]- July 2024
 - [AZNFS-mount #136](https://github.com/Azure/AZNFS-mount/pull/136)
   (NFSv3) Resolved the minor and major device numbers from the combined device ID received from the stat call to update the read-ahead configuration.


### PR DESCRIPTION
Issue Reported: [#132 on GitHub](https://github.com/Azure/AZNFS-mount/issues/132)
Root Cause Analysis (RCA):
The issue we encountered is related to the use of the softprops/action-gh-release GitHub Action for creating releases on Linux. While uploading release assets, the action defaults to using the repository’s default branch (main) for the assets it creates.

Details:
GitHub Action: softprops/action-gh-release
Problem: The action was utilizing the main branch to create release assets due to its default behavior.
Relevant Input: target_commitish - A string input that specifies the commitish value (branch or commit SHA) from which the Git tag is created. Defaults to the repository’s default branch.

Reference Documentation:
[softprops/action-gh-release README](https://github.com/softprops/action-gh-release?tab=readme-ov-file#inputs)
[github context documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)
[Similar Issue Discussion](https://github.com/softprops/action-gh-release/issues/392)