### PR TITLE
Fixing logs not coming on console & a corner case blob/file mismatch

### DIFF
--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -41,7 +41,17 @@ get_host_from_share()
 
     if [ -z "$host" -o -z "$share" ]; then
         eecho "Bad share name: ${hostshare}."
-        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container'."
+        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        return 1
+    fi
+
+    # Split host by "."
+    IFS=. read account hostprefix rest <<< "$host"
+
+    # Check if the prefix matches the expected azprefix
+    if [ "$hostprefix" != "$azprefix" ]; then
+        eecho "Bad share name: ${hostshare}."
+        eecho "Share must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
         return 1
     fi
 
@@ -157,6 +167,8 @@ parse_arguments "$@"
 
 nfs_vers=$(get_version_from_mount_options "$MOUNT_OPTIONS")
 if [ $? -ne 0 ]; then
+    eecho "$nfs_vers"
+    eecho "Mount failed!"
     exit 1
 fi
 
@@ -171,6 +183,8 @@ fi
 
 nfs_host=$(get_host_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
+    eecho "$nfs_host"
+    eecho "Mount failed!"
     exit 1
 fi
 
@@ -188,12 +202,15 @@ fi
 
 nfs_dir=$(get_dir_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
+    eecho "$nfs_dir"
+    eecho "Mount failed!"
     exit 1
 fi
 
 if [ -z "$nfs_dir" ]; then
     eecho "Bad share name: ${1}!"
-    eecho "Share to be mounted must be of the form 'account.$AZ_PREFIX.core.windows.net:/account/container'!"
+    eecho "Share to be mounted must be of the form 'account.$AZ_PREFIX.core.windows.net:/account/container' for vers=$nfs_vers."
+    eecho "Mount failed!"
     exit 1
 fi
 

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -41,7 +41,7 @@ get_host_from_share()
 
     if [ -z "$host" -o -z "$share" ]; then
         echo "Bad share name: ${hostshare}."
-        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers"
         return 1
     fi
 
@@ -51,7 +51,7 @@ get_host_from_share()
     # Check if the prefix matches the expected azprefix
     if [ "$hostprefix" != "$azprefix" ]; then
         echo "Bad share name: ${hostshare}."
-        echo "Share must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Share must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers"
         return 1
     fi
 
@@ -78,7 +78,7 @@ get_dir_from_share()
 
     if [ $is_bad_share_name == "true" ]; then
         echo "Bad share name: ${hostshare}."
-        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers"
         return 1
     fi
 
@@ -209,7 +209,7 @@ fi
 
 if [ -z "$nfs_dir" ]; then
     eecho "Bad share name: ${1}!"
-    eecho "Share to be mounted must be of the form 'account.$AZ_PREFIX.core.windows.net:/account/container' for vers=$nfs_vers."
+    eecho "Share to be mounted must be of the form 'account.$AZ_PREFIX.core.windows.net:/account/container' for vers=$nfs_vers"
     eecho "Mount failed!"
     exit 1
 fi

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -78,7 +78,7 @@ get_dir_from_share()
 
     if [ $is_bad_share_name == "true" ]; then
         eecho "Bad share name: ${hostshare}."
-        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container'."
+        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
         return 1
     fi
 

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -167,7 +167,7 @@ parse_arguments "$@"
 
 nfs_vers=$(get_version_from_mount_options "$MOUNT_OPTIONS")
 if [ $? -ne 0 ]; then
-    eecho "$nfs_vers"
+    echo "$nfs_vers"
     eecho "Mount failed!"
     exit 1
 fi
@@ -183,7 +183,7 @@ fi
 
 nfs_host=$(get_host_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
-    eecho "$nfs_host"
+    echo "$nfs_host"
     eecho "Mount failed!"
     exit 1
 fi
@@ -202,7 +202,7 @@ fi
 
 nfs_dir=$(get_dir_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
-    eecho "$nfs_dir"
+    echo "$nfs_dir"
     eecho "Mount failed!"
     exit 1
 fi

--- a/src/mountscript.sh
+++ b/src/mountscript.sh
@@ -40,8 +40,8 @@ get_host_from_share()
     IFS=: read host share <<< "$hostshare"
 
     if [ -z "$host" -o -z "$share" ]; then
-        eecho "Bad share name: ${hostshare}."
-        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Bad share name: ${hostshare}."
+        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
         return 1
     fi
 
@@ -50,8 +50,8 @@ get_host_from_share()
 
     # Check if the prefix matches the expected azprefix
     if [ "$hostprefix" != "$azprefix" ]; then
-        eecho "Bad share name: ${hostshare}."
-        eecho "Share must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Bad share name: ${hostshare}."
+        echo "Share must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
         return 1
     fi
 
@@ -77,8 +77,8 @@ get_dir_from_share()
     fi
 
     if [ $is_bad_share_name == "true" ]; then
-        eecho "Bad share name: ${hostshare}."
-        eecho "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
+        echo "Bad share name: ${hostshare}."
+        echo "Share to be mounted must be of the form 'account.$azprefix.core.windows.net:/account/container' for vers=$nfs_vers."
         return 1
     fi
 
@@ -97,7 +97,7 @@ get_version_from_mount_options()
     # Check if version is missing in mount command.
     #
     if [ -z "$mount_options" ] || [[ ! "$mount_options" == *"$ver_string"* ]]; then
-        eecho "Missing version in mount options. Example: 'vers=3'."
+        echo "Missing version in mount options. Example: 'vers=3'."
         exit 1
     fi
 
@@ -167,7 +167,7 @@ parse_arguments "$@"
 
 nfs_vers=$(get_version_from_mount_options "$MOUNT_OPTIONS")
 if [ $? -ne 0 ]; then
-    echo "$nfs_vers"
+    eecho "$nfs_vers"
     eecho "Mount failed!"
     exit 1
 fi
@@ -183,7 +183,7 @@ fi
 
 nfs_host=$(get_host_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
-    echo "$nfs_host"
+    eecho "$nfs_host"
     eecho "Mount failed!"
     exit 1
 fi
@@ -202,7 +202,7 @@ fi
 
 nfs_dir=$(get_dir_from_share "$1" "$AZ_PREFIX")
 if [ $? -ne 0 ]; then
-    echo "$nfs_dir"
+    eecho "$nfs_dir"
     eecho "Mount failed!"
     exit 1
 fi

--- a/src/nfsv3mountscript.sh
+++ b/src/nfsv3mountscript.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # NfSv3 logic for mount helper
 #
@@ -931,7 +933,7 @@ while [ $mount_retry_attempt -le $AZNFS_MAX_MOUNT_RETRIES ]; do
 
         exit 0  # Nothing in this script will run after this point.
     else
-        if echo "$mount_output" | grep -q "reason given by server: No such file or directory"; then
+        if echo "$mount_output" | grep -Eq "reason given by server: No such file or directory|mount point $mount_point does not exist"; then
             break
         fi
 

--- a/src/nfsv4mountscript.sh
+++ b/src/nfsv4mountscript.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #
 # NfSv4 logic for mount helper
 #


### PR DESCRIPTION
Fixing logs not coming on console & a corner case blob/file mismatch with vers=3

example1- output of 1st command not coming on console as vers is not present in mount options, but looking in aznfs.log file it is present:

_**root@nfsv3mhUbuntu22-aznfs-runner:/# mount -v -t aznfs -o ,proto=tcp palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container1 "/mnt/palash1"**_
root@nfsv3mhUbuntu22-aznfs-runner:/# cat /opt/microsoft/aznfs/data/aznfs.log
[v3] Wed Jul 31 2024 16:18:13.205 nfsv3mhUbuntu22-aznfs-runner 2735690: Starting aznfswatchdog for NFSv3...
[v3] Wed Jul 31 2024 16:18:13.276 nfsv3mhUbuntu22-aznfs-runner 2735690: Linux distribution: Ubuntu 22.04.4 LTS
[v3] Wed Jul 31 2024 16:18:13.284 nfsv3mhUbuntu22-aznfs-runner 2735690: Bash version: GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
[v4] Wed Jul 31 2024 16:18:13.699 nfsv3mhUbuntu22-aznfs-runner 2735756: Starting aznfswatchdog for NFSv4...
[v4] Wed Jul 31 2024 16:18:13.744 nfsv3mhUbuntu22-aznfs-runner 2735756: Linux distribution: Ubuntu 22.04.4 LTS
[v4] Wed Jul 31 2024 16:18:13.755 nfsv3mhUbuntu22-aznfs-runner 2735756: Bash version: GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
[v3] Wed Jul 31 2024 16:18:15.416 nfsv3mhUbuntu22-aznfs-runner 2735690: AZNFS version: 0.1.387
[v3] Wed Jul 31 2024 16:18:15.427 nfsv3mhUbuntu22-aznfs-runner 2735690: NAT table:
 Generated by iptables-save v1.8.7 on Wed Jul 31 16:18:15 2024
*nat
:PREROUTING ACCEPT [0:0]
:INPUT ACCEPT [0:0]
:OUTPUT ACCEPT [0:0]
:POSTROUTING ACCEPT [0:0]
COMMIT
 Completed on Wed Jul 31 16:18:15 2024
[v4] Wed Jul 31 2024 16:18:15.891 nfsv3mhUbuntu22-aznfs-runner 2735756: AZNFS version: 0.1.387
Wed Jul 31 2024 16:18:38.782 nfsv3mhUbuntu22-aznfs-runner 2736022: Got arguments: [palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container1 /mnt/palash1 -v -o rw,vers=3,proto=tcp]
[v3] Wed Jul 31 2024 16:18:38.886 nfsv3mhUbuntu22-aznfs-runner 2736034: Adding nolock mount option!
[v3] Wed Jul 31 2024 16:18:38.894 nfsv3mhUbuntu22-aznfs-runner 2736034: Adding retrans=6 mount option!
[v3] Wed Jul 31 2024 16:18:38.935 nfsv3mhUbuntu22-aznfs-runner 2736034: Trying IP prefix 10.161.
[v3] Wed Jul 31 2024 16:18:38.999 nfsv3mhUbuntu22-aznfs-runner 2736034: Using local IP (10.161.100.100) for aznfs.
[v3] Wed Jul 31 2024 16:18:39.037 nfsv3mhUbuntu22-aznfs-runner 2736034: nfs_host=[palashvijstorageaccount.blob.core.windows.net], nfs_ip=[20.60.185.161], nfs_dir=[/palashvijstorageaccount/container1], mount_point=[/mnt/palash1], options=[ -v], mount_options=[rw,vers=3,proto=tcp,sec=sys,nolock,retrans=6], local_ip=[10.161.100.100].
[v3] Wed Jul 31 2024 16:18:39.073 nfsv3mhUbuntu22-aznfs-runner 2736034: [Gatepass mount] mount.nfs: mount(2): No such file or directory
mount.nfs: mounting 10.161.100.100:/palashvijstorageaccount/container1/80a18d5c-9553-4c64-88dd-d7553c6b3beb failed, reason given by server: No such file or directory
mount.nfs: timeout set for Wed Jul 31 16:20:39 2024
mount.nfs: trying text-based options 'vers=3,proto=tcp,sec=sys,nolock,retrans=6,port=2048,mountport=2048,addr=10.161.100.100'
[v3] Wed Jul 31 2024 16:18:39.127 nfsv3mhUbuntu22-aznfs-runner 2736034: mount.nfs: timeout set for Wed Jul 31 16:20:39 2024
mount.nfs: trying text-based options 'vers=3,proto=tcp,sec=sys,nolock,retrans=6,port=2048,mountport=2048,addr=10.161.100.100'
[v3] Wed Jul 31 2024 16:18:39.134 nfsv3mhUbuntu22-aznfs-runner 2736034: Mount completed: palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container1 on /mnt/palash1 using proxy IP 10.161.100.100 and endpoint IP 20.60.185.161
[v3] Wed Jul 31 2024 16:18:39.150 nfsv3mhUbuntu22-aznfs-runner 2736034: Read ahead size for /mnt/palash1 set to 16384 KB!
_**Wed Jul 31 2024 16:19:03.892 nfsv3mhUbuntu22-aznfs-runner 2736319: Got arguments: [palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container1 /mnt/palash1 -v -o rw,proto=tcp]
Wed Jul 31 2024 16:19:03.899 nfsv3mhUbuntu22-aznfs-runner 2736319: Missing version in mount options. Example: 'vers=3'**._

************************************

REASON 2- If we pass 4.1 as vers, for a FQDN with blob, nfsv4 code can causes issue:

Wed Jul 31 2024 15:53:39.420 nfsv3mhUbuntu22-aznfs-runner 2727242: Got arguments: [palashvijstorageaccount.blob.core.windows.net:/palashvijstorageaccount/container1 /mnt/palash1 -v -o rw,vers=4.1,proto=tcp]
[v4] Wed Jul 31 2024 15:53:39.451 nfsv3mhUbuntu22-aznfs-runner 2727254: nfs_host=[palashvijstorageaccount.blob.core.windows.net], nfs_dir=[/palashvijstorageaccount/container1], mount_point=[/mnt/palash1], options=[ -v], mount_options=[rw,vers=4.1,proto=tcp].
[v4] Wed Jul 31 2024 15:53:39.459 nfsv3mhUbuntu22-aznfs-runner 2727254: Mount nfs share with TLS.
[v4] Wed Jul 31 2024 15:53:39.486 nfsv3mhUbuntu22-aznfs-runner 2727254: nfs_dir=[/palashvijstorageaccount/container1], mount_point=[/mnt/palash1], options=[ -v], mount_options=[rw,vers=4.1,proto=tcp].
[v4] Wed Jul 31 2024 15:53:39.508 nfsv3mhUbuntu22-aznfs-runner 2727254: Available Port: 20049
[v4] Wed Jul 31 2024 15:53:44.231 nfsv3mhUbuntu22-aznfs-runner 2727053: accept_port: 20049
[v4] Wed Jul 31 2024 15:53:44.241 nfsv3mhUbuntu22-aznfs-runner 2727053: No mounted shares for host palashvijstorageaccount.blob.core.windows.net, deleting from /opt/microsoft/aznfs/data/mountmapv4 [palashvijstorageaccount.blob.core.windows.net;/etc/stunnel/microsoft/aznfs/nfsv4_fileShare/stunnel_palashvijstorageaccount.conf;/etc/stunnel/microsoft/aznfs/nfsv4_fileShare/logs/stunnel_palashvijstorageaccount.log;/etc/stunnel/microsoft/aznfs/nfsv4_fileShare/logs/stunnel_palashvijstorageaccount.pid;3953859881].
[v4] Wed Jul 31 2024 15:55:49.268 nfsv3mhUbuntu22-aznfs-runner 2727254: mount.nfs: Connection refused
_**[v4] Wed Jul 31 2024 15:55:49.276 nfsv3mhUbuntu22-aznfs-runner 2727254: Mount completed: 127.0.0.1:/palashvijstorageaccount/container1 on /mnt/palash1 with port:20049
[v4] Wed Jul 31 2024 15:55:49.284 nfsv3mhUbuntu22-aznfs-runner 2727254: Mount failed!**_

************************************
SHELLCHECK OUTPUT:

In /opt/microsoft/aznfs/nfsv3mountscript.sh line 1:
#
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

For more information:
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
=== Checking /opt/microsoft/aznfs/nfsv4mountscript.sh for errors ===

In /opt/microsoft/aznfs/nfsv4mountscript.sh line 1:
#
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

