### PR TITLE
[BUG][Mountscript] Exit on Unsupported Distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,6 @@ aznfswatchdog service.
   `export AZNFS_PING_LOCAL_IP_BEFORE_USE=1`.
 - Check https://learn.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to for more
   information regarding NFSv3 mount.
-- Starting November 2024, the AZNFS mount helper install script now bails out on unsupported distros, rather than defaulting to yum as the package manager. Existing users on unsupported distros
-  may experience disruptions if they rely on auto-updates. They can force package manager of choice using env variable 'AZNFS_FORCE_PACKAGE_MANAGER' which can take following values 'apt', 'yum',
-  'dnf', or 'zypper'
 
 
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ aznfswatchdog service.
   `export AZNFS_PING_LOCAL_IP_BEFORE_USE=1`.
 - Check https://learn.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to for more
   information regarding NFSv3 mount.
+- Starting November 2024, the AZNFS mount helper install script now bails out on unsupported distros, rather than defaulting to yum as the package manager. Existing users on unsupported distros
+  may experience disruptions if they rely on auto-updates. They can force package manager of choice using env variable 'AZNFS_FORCE_PACKAGE_MANAGER' which can take following values 'apt', 'yum',
+  'dnf', or 'zypper'
+
+
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ aznfswatchdog service.
   information regarding NFSv3 mount.
 
 
-
-
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It starts a systemd service named **aznfswatchdog** which monitors the change in
 Blob NFS shares. If it detects a change in endpoint IP, aznfswatchdog will update the iptables DNAT rule and NFS
 traffic will be forwarded to new endpoint IP.
 > [!NOTE]
-> After an Azure Blob NFS endpoint is unmounted, the local proxy IP-to-endpoint mapping remains cached in the mountmap for 5 minutes. If the same endpoint is remounted within this period, it will automatically reuse the previous proxy IP address.
+> After an Azure Blob NFS endpoint is unmounted, the local proxy IP-to-endpoint mapping remains cached in the mountmap for 5 minutes. If the same endpoint is remounted within this period, it will automatically reuse the previous proxy IP address. During this period, it will ignore `AZNFS_IP_PREFIXES` environment variable if it is set.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ IP prefixes with either 2 or 3 octets can be set `f.e. 10.100 10.100.100 172.16 
 It starts a systemd service named **aznfswatchdog** which monitors the change in IP address for all the mounted Azure
 Blob NFS shares. If it detects a change in endpoint IP, aznfswatchdog will update the iptables DNAT rule and NFS
 traffic will be forwarded to new endpoint IP.
+> [!NOTE]
+> After an Azure Blob NFS endpoint is unmounted, the local proxy IP-to-endpoint mapping remains cached in the mountmap for 5 minutes. If the same endpoint is remounted within this period, it will automatically reuse the previous proxy IP address.
 
 ## Limitations
 

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -303,19 +303,19 @@ ensure_pkg()
         case "$AZNFS_FORCE_PACKAGE_MANAGER" in
             apt)
                 apt=1
-                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing package manager '$AZNFS_FORCE_PACKAGE_MANAGER' on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 apt install -y $pkg
                 ;;
             yum|dnf)
                 yum=$AZNFS_FORCE_PACKAGE_MANAGER
-                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing package manager '$AZNFS_FORCE_PACKAGE_MANAGER' on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 $yum install -y $pkg
                 ;;
             zypper)
                 zypper=1
-                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing package manager '$AZNFS_FORCE_PACKAGE_MANAGER' on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 zypper install -y $pkg
                 ;;

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -289,7 +289,7 @@ ensure_pkg()
         fi
         apt=1
         apt install -y $pkg
-    elif [ "$distro" == "centos" -o "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" ]; then
+    elif [ "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" ]; then
         # lsb_release package is called redhat-lsb-core in redhat/centos.
         if [ "$pkg" == "lsb-release" ]; then
             pkg="redhat-lsb-core"
@@ -324,6 +324,11 @@ ensure_pkg()
                 exit 1
                 ;;
         esac
+        install_error=$?
+        if [ $install_error -ne 0 ]; then
+            eecho "[FATAL] Error installing AZNFS (Error: $install_error)"
+            exit 1
+        fi
     else
         eecho "[FATAL] Unsupported linux distro <$distro>"
         pecho "Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros"

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -299,10 +299,33 @@ ensure_pkg()
     elif [ "$distro" == "sles" ]; then
         zypper=1
         zypper install -y $pkg
+    elif [ -n "$AZNFS_FORCE_PACKAGE_MANAGER" ]; then
+        case "$AZNFS_FORCE_PACKAGE_MANAGER" in
+            apt)
+                apt=1
+                wecho "[WARNING] Using apt as overridden package manager on unsupported distro."
+                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                ;;
+            yum|dnf)
+                yum=1
+                wecho "[WARNING] Using yum/dnf as overridden package manager on unsupported distro."
+                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                ;;
+            zypper)
+                zypper=1
+                wecho "[WARNING] Using zypper as overridden package manager on unsupported distro."
+                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                ;;
+            *)
+                weecho "[FATAL] Unsupported value for AZNFS_FORCE_PACKAGE_MANAGER <$AZNFS_FORCE_PACKAGE_MANAGER>. Use 'apt', 'yum', 'dnf', or 'zypper'"
+                exit 1
+                ;;
+        esac
+    fi
     else
-        eecho "[FATAL] Unknown linux distro"
+        eecho "[FATAL] Unsupported linux distro <$distro>"
+        pecho "Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros, or"
         pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'"
-        pecho "If the problem persists, contact Microsoft support."
         exit 1
     fi
 }

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -299,7 +299,13 @@ ensure_pkg()
     elif [ "$distro" == "sles" ]; then
         zypper=1
         zypper install -y $pkg
+    else
+        eecho "[FATAL] Unknown linux distro"
+        pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'"
+        pecho "If the problem persists, contact Microsoft support."
+        exit 1
     fi
+    
 }
 
 verify_super_user()

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -303,16 +303,19 @@ ensure_pkg()
         case "$AZNFS_FORCE_PACKAGE_MANAGER" in
             apt)
                 apt=1
+                apt install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;
             yum|dnf)
                 yum=$AZNFS_FORCE_PACKAGE_MANAGER
+                $yum install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;
             zypper)
                 zypper=1
+                zypper install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -305,7 +305,6 @@ ensure_pkg()
         pecho "If the problem persists, contact Microsoft support."
         exit 1
     fi
-    
 }
 
 verify_super_user()

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -384,6 +384,7 @@ case "${__m}:${__s}" in
             eecho "[FATAL] Unknown linux distro, /etc/os-release not found!"
             pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'"
             pecho "If the problem persists, contact Microsoft support."
+            exit 1
         fi
         ;;
     *)

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -289,7 +289,7 @@ ensure_pkg()
         fi
         apt=1
         apt install -y $pkg
-    elif [ "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" ]; then
+    elif [ "$distro" == "centos" -o "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" ]; then
         # lsb_release package is called redhat-lsb-core in redhat/centos.
         if [ "$pkg" == "lsb-release" ]; then
             pkg="redhat-lsb-core"

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -326,8 +326,8 @@ ensure_pkg()
         esac
     else
         eecho "[FATAL] Unsupported linux distro <$distro>"
-        pecho "Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros, or"
-        pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'"
+        pecho "Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros"
+        pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest' or try running install after setting env variable 'AZNFS_FORCE_PACKAGE_MANAGER' to one of 'apt', 'yum', 'dnf', or 'zypper'"
         exit 1
     fi
 }
@@ -412,7 +412,7 @@ case "${__m}:${__s}" in
             distro_id=$(canonicalize_distro_id $distro_id)
         else
             eecho "[FATAL] Unknown linux distro, /etc/os-release not found!"
-            pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'"
+            pecho "Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest' or try running install after setting env variable 'AZNFS_FORCE_PACKAGE_MANAGER' to one of 'apt', 'yum', 'dnf', or 'zypper'"
             pecho "If the problem persists, contact Microsoft support."
             exit 1
         fi

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -303,21 +303,21 @@ ensure_pkg()
         case "$AZNFS_FORCE_PACKAGE_MANAGER" in
             apt)
                 apt=1
-                wecho "[WARNING] Using apt as overridden package manager on unsupported distro."
-                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;
             yum|dnf)
-                yum=1
-                wecho "[WARNING] Using yum/dnf as overridden package manager on unsupported distro."
-                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                yum=$AZNFS_FORCE_PACKAGE_MANAGER
+                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;
             zypper)
                 zypper=1
-                wecho "[WARNING] Using zypper as overridden package manager on unsupported distro."
-                wecho "[WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for assistance if issues arise."
+                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
                 ;;
             *)
-                weecho "[FATAL] Unsupported value for AZNFS_FORCE_PACKAGE_MANAGER <$AZNFS_FORCE_PACKAGE_MANAGER>. Use 'apt', 'yum', 'dnf', or 'zypper'"
+                eecho "[FATAL] Unsupported value for AZNFS_FORCE_PACKAGE_MANAGER <$AZNFS_FORCE_PACKAGE_MANAGER>. Use 'apt', 'yum', 'dnf', or 'zypper'"
                 exit 1
                 ;;
         esac
@@ -485,8 +485,8 @@ elif [ $zypper -eq 1 ]; then
     perform_aznfs_update
 
 else
-    install_cmd="yum"
-    current_version=$(yum info aznfs 2>/dev/null | grep "^Version" | tr -d " " | cut -d ':' -f2)
+    install_cmd=$yum
+    current_version=$($install_cmd info aznfs 2>/dev/null | grep "^Version" | tr -d " " | cut -d ':' -f2)
     # Without current version, auto-update cannot proceed.
     if [ "$RUN_MODE" == "auto-update" ] && [ -z "$current_version" ]; then
         eecho "Unable to retrieve the current version of AZNFS, exiting!"

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -303,19 +303,19 @@ ensure_pkg()
         case "$AZNFS_FORCE_PACKAGE_MANAGER" in
             apt)
                 apt=1
-                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 apt install -y $pkg
                 ;;
             yum|dnf)
                 yum=$AZNFS_FORCE_PACKAGE_MANAGER
-                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 $yum install -y $pkg
                 ;;
             zypper)
                 zypper=1
-                wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
+                wecho "[WARNING] Forcing '$AZNFS_FORCE_PACKAGE_MANAGER' package manager on unsupported distro <$distro>"
                 wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
                 zypper install -y $pkg
                 ;;

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -303,21 +303,21 @@ ensure_pkg()
         case "$AZNFS_FORCE_PACKAGE_MANAGER" in
             apt)
                 apt=1
-                apt install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
-                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
+                wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
+                apt install -y $pkg
                 ;;
             yum|dnf)
                 yum=$AZNFS_FORCE_PACKAGE_MANAGER
-                $yum install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
-                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
+                wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
+                $yum install -y $pkg
                 ;;
             zypper)
                 zypper=1
-                zypper install -y $pkg
                 wecho "[WARNING] Forcing $AZNFS_FORCE_PACKAGE_MANAGER package manager on unsupported distro <$distro>"
-                wecho "[WARNING] Proceeding with the AZNFS installation, Please contact Microsoft support in case of any issues."
+                wecho "[WARNING] Proceeding with the AZNFS installation, please contact Microsoft support in case of any issues."
+                zypper install -y $pkg
                 ;;
             *)
                 eecho "[FATAL] Unsupported value for AZNFS_FORCE_PACKAGE_MANAGER <$AZNFS_FORCE_PACKAGE_MANAGER>. Use 'apt', 'yum', 'dnf', or 'zypper'"

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -321,7 +321,6 @@ ensure_pkg()
                 exit 1
                 ;;
         esac
-    fi
     else
         eecho "[FATAL] Unsupported linux distro <$distro>"
         pecho "Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros, or"

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -11,13 +11,6 @@ AKS_USER="false"
 RELEASE_NUMBER_FOR_AKS=x.y.z
 
 #
-# In case of unsupported distros already using mount-helper require auto update enabled,
-# they need to set AZNFS_FORCE_PACKAGE_MANAGER accordingly else we fail to update package amd remain on the same version.
-#
-AZNFS_FORCE_PACKAGE_MANAGER="${AZNFS_FORCE_PACKAGE_MANAGER:-DEFAULT}"
-export AZNFS_FORCE_PACKAGE_MANAGER
-
-#
 # How often does the watchdog look for unmounts and/or IP address changes for
 # Blob endpoints.
 #

--- a/src/aznfswatchdog
+++ b/src/aznfswatchdog
@@ -11,6 +11,13 @@ AKS_USER="false"
 RELEASE_NUMBER_FOR_AKS=x.y.z
 
 #
+# In case of unsupported distros already using mount-helper require auto update enabled,
+# they need to set AZNFS_FORCE_PACKAGE_MANAGER accordingly else we fail to update package amd remain on the same version.
+#
+AZNFS_FORCE_PACKAGE_MANAGER="${AZNFS_FORCE_PACKAGE_MANAGER:-DEFAULT}"
+export AZNFS_FORCE_PACKAGE_MANAGER
+
+#
 # How often does the watchdog look for unmounts and/or IP address changes for
 # Blob endpoints.
 #


### PR DESCRIPTION
### TESTING (29TH OCTOBER 2024)
  CASES COVERED-

![image](https://github.com/user-attachments/assets/e98e6c78-ee72-4249-a906-c91901a710a4)
![image](https://github.com/user-attachments/assets/217648d5-9b2d-427f-8681-09ccb5c509cd)
![image](https://github.com/user-attachments/assets/c8b411c5-b8a3-4acf-a649-18cc23a49c13)
![image](https://github.com/user-attachments/assets/b85d1501-563d-4ea9-826a-32f87fa984d7)



  
  

### (28TH OCTOBER,2024)
TESTING PROCESS-

commented out following in aznfs_install.sh

    if [ "$distro" == "ubuntu" ]; then
        if ! $apt_update_done; then
            apt -y update
            if [ $? -ne 0 ]; then
                echo
                eecho "\"apt update\" failed"
                eecho "Please make sure \"apt update\" runs successfully and then try again!"
                echo
                exit 1
            fi
            # Need to run apt update only once.
            apt_update_done=true
        fi
        apt=1
        apt install -y $pkg


used AZNFS_FORCE_PACKAGE_MANAGER = apt (for ubuntu)-

  root@nfsv3mhUbuntu22-aznfs-runner:/home/nfsv3mhUbuntu22-aznfs-runner# **unset AZNFS_FORCE_PACKAGE_MANAGER**
  root@nfsv3mhUbuntu22-aznfs-runner:/home/nfsv3mhUbuntu22-aznfs-runner# ./aznfs_install.sh
  Retrieving distro info from /etc/os-release...
  _**[FATAL] Unsupported linux distro <ubuntu>
  Check 'https://github.com/Azure/AZNFS-mount/blob/main/README.md#supported-distros' to see the list of supported distros, or
  Download .deb/.rpm package based on your distro from 'https://github.com/Azure/AZNFS-mount/releases/latest'**_
  root@nfsv3mhUbuntu22-aznfs-runner:/home/nfsv3mhUbuntu22-aznfs-runner# **export AZNFS_FORCE_PACKAGE_MANAGER=apt**
  root@nfsv3mhUbuntu22-aznfs-runner:/home/nfsv3mhUbuntu22-aznfs-runner# ./aznfs_install.sh
  Retrieving distro info from /etc/os-release...
  **[WARNING] Using apt as overridden package manager on unsupported distro.
  [WARNING] Proceeding with the AZNFS installation; it may or may not succeed. Please contact Microsoft support for** assistance if issues arise.
  Reading package lists... Done
  Building dependency tree... Done
  Reading state information... Done
  Note, selecting 'aznfs' instead of '/tmp/aznfs-0.1.396-1_amd64.deb'
  The following packages were automatically installed and are no longer required:
    linux-azure-6.5-cloud-tools-6.5.0-1018 linux-azure-6.5-cloud-tools-6.5.0-1019 linux-azure-6.5-cloud-tools-6.5.0-1021 linux-azure-6.5-cloud-tools-6.5.0-1022 linux-azure-6.5-cloud-tools-6.5.0-1023 linux-azure-6.5-cloud-tools-6.5.0-1024
    linux-azure-6.5-headers-6.5.0-1018 linux-azure-6.5-headers-6.5.0-1019 linux-azure-6.5-headers-6.5.0-1021 linux-azure-6.5-headers-6.5.0-1022 linux-azure-6.5-headers-6.5.0-1023 linux-azure-6.5-headers-6.5.0-1024
    linux-azure-6.5-tools-6.5.0-1018 linux-azure-6.5-tools-6.5.0-1019 linux-azure-6.5-tools-6.5.0-1021 linux-azure-6.5-tools-6.5.0-1022 linux-azure-6.5-tools-6.5.0-1023 linux-azure-6.5-tools-6.5.0-1024 linux-cloud-tools-6.5.0-1018-azure
    linux-cloud-tools-6.5.0-1019-azure linux-cloud-tools-6.5.0-1021-azure linux-cloud-tools-6.5.0-1022-azure linux-cloud-tools-6.5.0-1023-azure linux-cloud-tools-6.5.0-1024-azure linux-headers-6.5.0-1018-azure
    linux-headers-6.5.0-1019-azure linux-headers-6.5.0-1021-azure linux-headers-6.5.0-1022-azure linux-headers-6.5.0-1023-azure linux-headers-6.5.0-1024-azure linux-image-6.5.0-1018-azure linux-image-6.5.0-1019-azure
    linux-image-6.5.0-1021-azure linux-image-6.5.0-1022-azure linux-image-6.5.0-1023-azure linux-image-6.5.0-1024-azure linux-modules-6.5.0-1018-azure linux-modules-6.5.0-1019-azure linux-modules-6.5.0-1021-azure
    linux-modules-6.5.0-1022-azure linux-modules-6.5.0-1023-azure linux-modules-6.5.0-1024-azure linux-tools-6.5.0-1018-azure linux-tools-6.5.0-1019-azure linux-tools-6.5.0-1021-azure linux-tools-6.5.0-1022-azure
    linux-tools-6.5.0-1023-azure linux-tools-6.5.0-1024-azure net-tools stunnel4
  Use 'sudo apt autoremove' to remove them.
  The following NEW packages will be installed:
    aznfs
  0 upgraded, 1 newly installed, 0 to remove and 40 not upgraded.
  Need to get 0 B/397 kB of archives.
  After this operation, 0 B of additional disk space will be used.
  Get:1 /tmp/aznfs-0.1.396-1_amd64.deb aznfs amd64 0.1.396 [397 kB]
  Selecting previously unselected package aznfs.
  (Reading database ... 265804 files and directories currently installed.)
  Preparing to unpack /tmp/aznfs-0.1.396-1_amd64.deb ...
  Unpacking aznfs (0.1.396) ...
  Setting up aznfs (0.1.396) ...
  Created symlink /etc/systemd/system/nfs-client.target.wants/aznfswatchdog.service → /lib/systemd/system/aznfswatchdog.service.
  Scanning processes...
  Scanning linux images...
  
  Running kernel seems to be up-to-date.
  
  No services need to be restarted.
  
  No containers need to be restarted.
  
  No user sessions are running outdated binaries.
  
  No VM guests are running outdated hypervisor (qemu) binaries on this host.
  Version 0.1.396 of aznfs mount helper is successfully installed
  
