### PR TITLE
Removed unnecessary/unsupported config from sample config.

### DIFF
--- a/turbonfs/inc/util.h
+++ b/turbonfs/inc/util.h
@@ -128,8 +128,7 @@ bool is_valid_lookupcache(const std::string& lookupcache)
 static inline
 bool is_valid_consistency(const std::string& consistency)
 {
-    return (consistency == "solowriter" || consistency == "standardnfs" ||
-            consistency == "azurempa");
+    return (consistency == "solowriter" || consistency == "standardnfs");
 }
 
 static inline

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -29,16 +29,9 @@ rsize: 3145728
 wsize: 3145728
 
 # count/maxcount value passed in READDIR/READDIRPLUS RPC requests.
-# valid range: [8192, 4194304]
+# valid range: [8192, 3145728]
 # effective value depends on the server support.
 readdir_maxcount: 1048576
-
-#
-# aznfsclient will disable (to be precise, resist) OOM killing as it's an
-# important process and killing it may cause data loss. If you don't want
-# aznfsclient to do that, set this to false.
-#
-oom_kill_disable: true
 
 #
 # Consistency config.
@@ -73,20 +66,9 @@ oom_kill_disable: true
 #   Use this if you want to access files updated by this client, from other
 #   non-NFS protocols.
 #
-# valid values: only solowriter for now.
+# valid values: solowriter and standardnfs, for now.
 #
 consistency: solowriter
-
-#
-# Misc options
-# fuse_* config variables control some fuse configurable value.
-# fuse_max_threads has the same effect as fuse cmdline option "-o max_threads=".
-# fuse_max_idle_threads has the same effect as fuse cmdline option "-o max_idle_threads=".
-# Value of -1 for these imply "use fuse defaults". Fuse defaults must be fine for most cases.
-#
-fuse_max_threads: -1
-fuse_max_idle_threads: -1
-fuse_max_background: 4096
 
 #
 # Cache config
@@ -142,10 +124,8 @@ cache.data.kernel.enable: false
 #cache.data.user.max_size_mb: 4096
 
 #
-# Config controlling misc system behaviour.
+# aznfsclient will disable (to be precise, resist) OOM killing as it's an
+# important process and killing it may cause data loss. If you don't want
+# aznfsclient to do that, set this to false.
 #
-sys.force_stable_writes: true
-sys.resolve_before_reconnect: true
-sys.nodrc.remove_noent_as_success: true
-sys.nodrc.rename_noent_as_success: true
-sys.nodrc.create_exist_as_success: true
+oom_kill_disable: true

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -1,46 +1,37 @@
 #
-# Share details
-# These will ONLY be used if the user runs the binary directly or passes
-# "none" as source in the mount command. In that case account and container
-# are mandatory, cloud_suffix can be guessed and port is default 2048.
-#
-account: sjc22prdste06hnfsv3acc1
-container: nfsv3test
-
-#cloud_suffix: blob.core.windows.net
-#cloud_suffix: blob.preprod.core.windows.net
-#port: 2048
-
-#
-# Auth Config
-#
-auth: false
-
-#
 # NFS mount options
 # These have the same name and meaning as Linux NFS client mount options.
 # Also note that only a subset of Linux mount options are supported.
-# readdir_maxcount
-# lookupcache: all|none|pos|positive
 #
+
+# valid range: [1, 256]
 nconnect: 96
+
+# valid range: [100, 6000]
 timeo: 600
+
+# valid range: [1, 100]
 retrans: 2
+
+# valid range: [1, 3600]
 acregmin: 3
 acregmax: 60
 acdirmin: 30
 acdirmax: 60
 actimeo: 300
+
+# valid values: all|none|pos|positive
 lookupcache: all
+
+# valid range: [1048576, 3145728]
+# also rsize must not be greater than wsize.
 rsize: 3145728
 wsize: 3145728
 
-#
-# Option controlling transport security, takes following values:
-# none: do not use TLS encryption.
-# tls: use TLS encryption, as defined in RPC-with-TLS RFC 9289.
-#
-xprtsec: none
+# count/maxcount value passed in READDIR/READDIRPLUS RPC requests.
+# valid range: [8192, 4194304]
+# effective value depends on the server support.
+readdir_maxcount: 1048576
 
 #
 # aznfsclient will disable (to be precise, resist) OOM killing as it's an
@@ -82,6 +73,8 @@ oom_kill_disable: true
 #   Use this if you want to access files updated by this client, from other
 #   non-NFS protocols.
 #
+# valid values: only solowriter for now.
+#
 consistency: solowriter
 
 #
@@ -91,7 +84,6 @@ consistency: solowriter
 # fuse_max_idle_threads has the same effect as fuse cmdline option "-o max_idle_threads=".
 # Value of -1 for these imply "use fuse defaults". Fuse defaults must be fine for most cases.
 #
-readdir_maxcount: 1048576
 fuse_max_threads: -1
 fuse_max_idle_threads: -1
 fuse_max_background: 4096
@@ -148,14 +140,6 @@ cache.readdir.kernel.enable: true
 cache.data.kernel.enable: false
 #cache.data.user.max_size_mb: "60%"
 #cache.data.user.max_size_mb: 4096
-
-#
-# These are currently not supported.
-#
-#filecache.enable: false
-#filecache.cachedir: /mnt
-#filecache.max_size_gb: 1000
-#cache_max_mb: 4096
 
 #
 # Config controlling misc system behaviour.

--- a/turbonfs/src/config.cpp
+++ b/turbonfs/src/config.cpp
@@ -335,6 +335,11 @@ bool aznfsc_cfg::set_defaults_and_sanitize()
         readdir_maxcount = 1048576;
     if (readahead_kb == -1)
         readahead_kb = AZNFSCFG_READAHEAD_KB_DEF;
+
+    if (fuse_max_background == -1) {
+        fuse_max_background = AZNFSCFG_FUSE_MAX_BG_DEF;
+    }
+
     if (cache.data.user.enable) {
         if (cache.data.user.max_size_mb < 0) {
             /*


### PR DESCRIPTION
account and container are not read from config, so remove those. Phase1 doesn't have support for auth and tls, remove those. port is something which we don't want people to use anything other than 2048, so better to remove and avoid confusion.
Similarly cloud_suffix etc are also not needed.
Also provided valid ranges and valid values for various config for implicit documentation.
Also removed some filecache related config which we don't support now.

Overall much simplified config that avoids confusion.