### PR TITLE
Put turbo logs on stdout

### DIFF
--- a/src/nfsv3mountscript.sh
+++ b/src/nfsv3mountscript.sh
@@ -23,6 +23,12 @@ mount_point=$5
 DEFAULT_AZNFS_IP_PREFIXES="10.161 192.168 172.16"
 IP_PREFIXES="${AZNFS_IP_PREFIXES:-${DEFAULT_AZNFS_IP_PREFIXES}}"
 
+#
+# Directory where the turbo log file will be created.
+# User can override it with AZNFSC_LOGDIR env variable.
+#
+AZNFSC_LOGDIR="${AZNFSC_LOGDIR:-/opt/microsoft/aznfs/data}"
+
 # Aznfs port, defaults to 2048.
 AZNFS_PORT="${AZNFS_PORT:-2048}"
 
@@ -947,6 +953,22 @@ create_aznfsclient_mount_args()
 
     # Finally add the mount point.
     AZNFSCLIENT_MOUNT_ARGS="$args $mount_point"
+
+    turbo_log=$AZNFSC_LOGDIR/turbo$(echo $mount_point | tr -s "/" "_").log
+    if [ ! -f $turbo_log ]; then
+        touch $turbo_log
+        if [ $? -ne 0 ]; then
+            eecho "[FATAL] Not able to create '${LOGFILE}'!"
+            eecho "Mount failed!"
+            exit 1
+        fi
+    fi
+
+    #
+    # Turbo mount uses different log file for each mount.
+    # All logs from here on will come in that log file.
+    #
+    LOGFILE=$turbo_log
 }
 
 #
@@ -979,7 +1001,15 @@ aznfsclient_mount()
     # Get the gatepass before the actual mount.
     #
     gatepass_mount
-    $AZNFSCLIENT_BINARY_PATH $AZNFSCLIENT_MOUNT_ARGS &
+    vecho "fuse command: $AZNFSCLIENT_BINARY_PATH $AZNFSCLIENT_MOUNT_ARGS -f"
+    vvecho "Using log file $LOGFILE"
+
+    #
+    # We append to the logfile w/o any support for re-opening log file for
+    # log rotation. Use copytruncate option in logrotate config.
+    # Redirect stderr too for capturing assert/asan failures.
+    #
+    $AZNFSCLIENT_BINARY_PATH $AZNFSCLIENT_MOUNT_ARGS -f >> $LOGFILE 2>&1 &
 
     vvecho "Waiting for mount to complete (timeout: 30 seconds)..."
 
@@ -1002,17 +1032,18 @@ aznfsclient_mount()
     # -1 -> some other error in mounting.
     # 
     if [ $read_status -gt 128 ]; then
-        eecho "Mount timed out, check for details!"
+        eecho "Mount timed out, check $LOGFILE for details!"
         return $read_status
     elif [ "$mount_status" == "-2" ]; then
         eecho "Auth enabled in config but 'az login' not detected"
         eecho "Please perform 'az login' and then try to mount again!"
+        eecho "Check $LOGFILE for details!"
         return 1
     elif [ "$mount_status" != "0" ]; then
         if [ -n "$mount_str" ]; then
             eecho "$mount_str"
         else
-            eecho "Mount failed with status $mount_status"
+            eecho "Mount failed with status $mount_status, check $LOGFILE for details!"
         fi
         return 1
     else

--- a/turbonfs/inc/aznfsc.h
+++ b/turbonfs/inc/aznfsc.h
@@ -143,6 +143,9 @@ typedef struct aznfsc_cfg
     // config.yaml file path specified using --config-file= cmdline option.
     const char *config_yaml = nullptr;
 
+    // Enable debug logging?
+    bool debug = false;
+
     /*************************************************
      **                Mount path                   **
      ** Identify the server and the export to mount **

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -22,6 +22,7 @@ container: nfsv3test
 # fuse_max_idle_threads has the same effect as fuse cmdline option "-o max_idle_threads=".
 # Value of -1 for these imply "use fuse defaults". Fuse defaults must be fine for most cases.
 #
+debug: false
 fuse_max_threads: -1
 fuse_max_idle_threads: -1
 fuse_max_background: 4096

--- a/turbonfs/src/config.cpp
+++ b/turbonfs/src/config.cpp
@@ -114,6 +114,8 @@ do { \
     try {
         YAML::Node config = YAML::LoadFile(config_yaml);
 
+        _CHECK_BOOL(debug);
+
         _CHECK_STR(account);
         _CHECK_STR(container);
         _CHECK_STR(cloud_suffix);


### PR DESCRIPTION
This helps as follows:
- no logs are missed during crash, also assert failures are capture in the logfile
- we can use logrotate to set rotate config

Also ensured all logs including initial logs come in the correct log file.