### PR TITLE
Personal/linuxsmiths/purge readdir cache after full dir enumerated (#…

### DIFF
--- a/turbonfs/inc/aznfsc.h
+++ b/turbonfs/inc/aznfsc.h
@@ -295,6 +295,9 @@ typedef struct aznfsc_cfg
              */
             struct {
                 const bool enable = true;
+
+                // Max userspace readdir cache size in MB.
+                int max_size_mb = -1;
             } user;
         } readdir;
 

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -89,8 +89,13 @@ consistency: solowriter
 # Attribute caching can be effectively disabled by setting actimeo to 0.
 #
 # Readdir data can be cached in the kernel and user caches.
-# User cache is always enabled.
+# User cache is always enabled. Its max size can be capped using the
+# cache.readdir.user.max_size_mb config (default 4096). This is the size of all
+# directory caches combined. Once the readdir cache size exceeds the max size,
+# further entries are not cached. This means that we won't get any readdir ahead
+# benefits, though it won't affect directory enumeration functionally.
 # kernel cache can be controlled using cache.readdir.kernel.enable config.
+# It's almost never beneficial to disable the kernel readdir cache.
 #
 # File data can be cached in the kernel and/or user caches.
 # User cache is always enabled, it can be memory and/or file backed (file
@@ -119,6 +124,7 @@ consistency: solowriter
 #readahead_kb: 16384
 cache.attr.user.enable: true
 cache.readdir.kernel.enable: true
+#cache.readdir.user.max_size_mb: 4096
 cache.data.kernel.enable: false
 #cache.data.user.max_size_mb: "60%"
 #cache.data.user.max_size_mb: 4096

--- a/turbonfs/src/config.cpp
+++ b/turbonfs/src/config.cpp
@@ -171,6 +171,8 @@ do { \
 
         _CHECK_BOOL(cache.attr.user.enable);
         _CHECK_BOOL(cache.readdir.kernel.enable);
+        _CHECK_INT(cache.readdir.user.max_size_mb,
+                   AZNFSCFG_CACHE_MAX_MB_MIN, AZNFSCFG_CACHE_MAX_MB_MAX);
         // User readdir cache cannot be turned off.
         assert(cache.readdir.user.enable);
         _CHECK_BOOL(cache.data.kernel.enable);
@@ -355,6 +357,18 @@ bool aznfsc_cfg::set_defaults_and_sanitize()
             }
         }
     }
+
+    if (cache.readdir.user.enable) {
+        /*
+         * If not set from config, set to default value of 4GB.
+         */
+        if (cache.readdir.user.max_size_mb == -1) {
+            cache.readdir.user.max_size_mb = 4096;
+        }
+
+        assert(cache.readdir.user.max_size_mb > 0);
+    }
+
     if (filecache.enable) {
         if (filecache.max_size_gb == -1)
             filecache.max_size_gb = AZNFSCFG_FILECACHE_MAX_GB_DEF;
@@ -467,6 +481,7 @@ done_cloud_suffix:
     AZLogDebug("cache.attr.user.enable = {}", cache.attr.user.enable);
     AZLogDebug("cache.readdir.kernel.enable = {}", cache.readdir.kernel.enable);
     AZLogDebug("cache.readdir.user.enable = {}", cache.readdir.user.enable);
+    AZLogDebug("cache.readdir.user.max_size_mb = {}", cache.readdir.user.max_size_mb);
     AZLogDebug("cache.data.kernel.enable = {}", cache.data.kernel.enable);
     AZLogDebug("cache.data.user.enable = {}", cache.data.user.enable);
     AZLogDebug("cache.data.user.max_size_mb = {}", cache.data.user.max_size_mb);

--- a/turbonfs/src/nfs_client.cpp
+++ b/turbonfs/src/nfs_client.cpp
@@ -1708,6 +1708,8 @@ void nfs_client::readdir(
     off_t offset,
     struct fuse_file_info* file)
 {
+    readdirectory_cache::num_readdir_calls_g++;
+
     struct rpc_task *tsk = rpc_task_helper->alloc_rpc_task(FUSE_READDIR);
     struct nfs_inode *inode = get_nfs_inode_from_ino(ino);
 
@@ -1725,6 +1727,8 @@ void nfs_client::readdirplus(
     off_t offset,
     struct fuse_file_info* file)
 {
+    readdirectory_cache::num_readdirplus_calls_g++;
+
     struct rpc_task *tsk = rpc_task_helper->alloc_rpc_task(FUSE_READDIRPLUS);
     struct nfs_inode *inode = get_nfs_inode_from_ino(ino);
 

--- a/turbonfs/src/nfs_inode.cpp
+++ b/turbonfs/src/nfs_inode.cpp
@@ -1720,6 +1720,17 @@ bool nfs_inode::release(fuse_req_t req)
      *
      * This is the close side of cto consistency. Any open after this point
      * will cause the file data to be fetched from the server.
+     *
+     * Note: For directory inodes this will clear the readdirectory_cache for
+     *       the inode. Few things to note:
+     *       1. With kernel readdir cache enabled, this should not affect
+     *          readdir performance. Infact this is a good thing to do as
+     *          readdirectory_cache for a directory will be rarely needed after
+     *          a directory is enumerated fully and its fd closed.
+     *       2. Since our readdirectory_cache doubles as DNLC cache too, this
+     *          may affect lookups as they won't hit the cache now.
+     *
+     *       TODO: Should this invalidation be controlled using a config?
      */
     invalidate_cache(true /* purge_now */);
     invalidate_attribute_cache();

--- a/turbonfs/src/rpc_readdir.cpp
+++ b/turbonfs/src/rpc_readdir.cpp
@@ -207,7 +207,8 @@ bool readdirectory_cache::add(const std::shared_ptr<struct directory_entry>& ent
     static const uint64_t max_cache =
         (aznfsc_cfg.cache.readdir.user.max_size_mb * 1024 * 1024ULL);
     assert(max_cache != 0);
-    const uint64_t max_single_cache = std::min((uint64_t) MAX_CACHE_SIZE_LIMIT, max_cache);
+    // Single cache must not be allowed to be more than half the global max.
+    const uint64_t max_single_cache = std::min((uint64_t) MAX_CACHE_SIZE_LIMIT, max_cache / 2);
 
     assert(entry != nullptr);
     assert(entry->name != nullptr);

--- a/turbonfs/src/rpc_stats.cpp
+++ b/turbonfs/src/rpc_stats.cpp
@@ -201,7 +201,7 @@ void rpc_stats_az::dump_stats()
                   " inodes silly-renamed (waiting for last close)\n";
 
     // Maximum cache size allowed in bytes.
-    static const uint64_t max_cache =
+    uint64_t max_cache =
         (aznfsc_cfg.cache.data.user.max_size_mb * 1024 * 1024ULL);
     assert(max_cache != 0);
 
@@ -222,7 +222,7 @@ void rpc_stats_az::dump_stats()
     str += "  " + std::to_string(bytes_chunk_cache::num_chunks_g) +
                   " chunks in chunkmap\n";
 
-    const double allocate_pct =
+    double allocate_pct =
         ((bytes_chunk_cache::bytes_allocated_g * 100.0) / max_cache);
     str += "  " + std::to_string(bytes_chunk_cache::bytes_allocated_g) +
                   " bytes allocated (" +
@@ -268,6 +268,41 @@ void rpc_stats_az::dump_stats()
                       " msec avg lock wait (" +
                       std::to_string(lockwait_pct) + "% had to wait)\n";
     }
+
+    // Maximum readdir cache size allowed in bytes.
+    max_cache =
+        (aznfsc_cfg.cache.readdir.user.max_size_mb * 1024 * 1024ULL);
+    assert(max_cache != 0);
+
+    str += "Readdir Cache statistics:\n";
+    if (aznfsc_cfg.cache.readdir.user.enable) {
+        str += "  " + std::to_string(aznfsc_cfg.cache.readdir.user.max_size_mb) +
+                      " MB user cache size configured\n";
+    } else {
+        str += "  user cache disabled\n";
+    }
+    if (aznfsc_cfg.cache.readdir.kernel.enable) {
+        str += "  kernel cache enabled\n";
+    } else {
+        str += "  kernel cache disabled\n";
+    }
+    str += "  " + std::to_string(readdirectory_cache::num_caches) +
+                  " directory caches\n";
+    str += "  " + std::to_string(readdirectory_cache::num_dirents_g) +
+                  " total directory entries cached\n";
+    allocate_pct =
+        ((readdirectory_cache::bytes_allocated_g * 100.0) / max_cache);
+    str += "  " + std::to_string(readdirectory_cache::bytes_allocated_g) +
+                  " bytes allocated (" +
+                  std::to_string(allocate_pct) + "%)\n";
+    str += "  " + std::to_string(readdirectory_cache::num_dirents_returned_g) +
+                  " directory entries returned to fuse over " +
+                  std::to_string(readdirectory_cache::num_readdir_calls_g) +
+                  " readdir and " +
+                  std::to_string(readdirectory_cache::num_readdirplus_calls_g) +
+                  " readdirplus calls\n";
+
+
 
     str += "Application statistics:\n";
     const uint64_t avg_app_read_size =

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -5841,6 +5841,7 @@ void rpc_task::send_readdir_or_readdirplus_response(
             startidx = 0;
             assert(0);
         } else {
+            readdirectory_cache::num_dirents_returned_g += num_entries_added;
             DEC_GBL_STATS(fuse_responses_awaited, 1);
         }
     } else {

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -4573,7 +4573,12 @@ static void readdir_callback(
      */
     task->get_stats().on_rpc_complete(rpc_get_pdu(rpc), NFS_STATUSX(rpc_status, res));
 
-    if (cookie_gap) {
+    /*
+     * "get_seq_last_cookie() == 0" is a common case when we purge the dircache
+     * if it grows beyond the configured limit. In that case all subsequent
+     * calls will see a cookie_gap and flood the logs.
+     */
+    if (cookie_gap && (dircache_handle->get_seq_last_cookie() != 0)) {
         AZLogWarn("[{}] readdir_callback: GAP in cookie requested ({} -> {})",
                   dir_ino, dircache_handle->get_seq_last_cookie(),
                   task->rpc_api->readdir_task.get_offset());
@@ -4982,7 +4987,12 @@ static void readdirplus_callback(
      */
     task->get_stats().on_rpc_complete(rpc_get_pdu(rpc), NFS_STATUSX(rpc_status, res));
 
-    if (cookie_gap) {
+    /*
+     * "get_seq_last_cookie() == 0" is a common case when we purge the dircache
+     * if it grows beyond the configured limit. In that case all subsequent
+     * calls will see a cookie_gap and flood the logs.
+     */
+    if (cookie_gap && (dircache_handle->get_seq_last_cookie() != 0)) {
         AZLogWarn("[{}] readdirplus_callback: GAP in cookie requested ({} -> {})",
                   dir_ino, dircache_handle->get_seq_last_cookie(),
                   task->rpc_api->readdir_task.get_offset());


### PR DESCRIPTION
…196)

* clear readdir cache after full directory enumeration

* Added readdir stats

* Remove clear_after_enumerate as we already do that from nfs_inode::release()

* Clear readdir cache if size exceeds per-cache threshold

* Honow global readdir cache limit, and more stats

* Limit per cache size to the global cache size.

---------

Co-authored-by: Nagendra Tomar <natomar@microsoft.com>
(cherry picked from commit ea2e003a039289943c78bcab03cc48d1b500831e)