### PR TITLE
Avoid log flooding when we purge dircache due to size limit

### DIFF
--- a/turbonfs/src/rpc_readdir.cpp
+++ b/turbonfs/src/rpc_readdir.cpp
@@ -207,7 +207,8 @@ bool readdirectory_cache::add(const std::shared_ptr<struct directory_entry>& ent
     static const uint64_t max_cache =
         (aznfsc_cfg.cache.readdir.user.max_size_mb * 1024 * 1024ULL);
     assert(max_cache != 0);
-    const uint64_t max_single_cache = std::min((uint64_t) MAX_CACHE_SIZE_LIMIT, max_cache);
+    // Single cache must not be allowed to be more than half the global max.
+    const uint64_t max_single_cache = std::min((uint64_t) MAX_CACHE_SIZE_LIMIT, max_cache / 2);
 
     assert(entry != nullptr);
     assert(entry->name != nullptr);

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -4573,7 +4573,12 @@ static void readdir_callback(
      */
     task->get_stats().on_rpc_complete(rpc_get_pdu(rpc), NFS_STATUSX(rpc_status, res));
 
-    if (cookie_gap) {
+    /*
+     * "get_seq_last_cookie() == 0" is a common case when we purge the dircache
+     * if it grows beyond the configured limit. In that case all subsequent
+     * calls will see a cookie_gap and flood the logs.
+     */
+    if (cookie_gap && (dircache_handle->get_seq_last_cookie() != 0)) {
         AZLogWarn("[{}] readdir_callback: GAP in cookie requested ({} -> {})",
                   dir_ino, dircache_handle->get_seq_last_cookie(),
                   task->rpc_api->readdir_task.get_offset());
@@ -4982,7 +4987,12 @@ static void readdirplus_callback(
      */
     task->get_stats().on_rpc_complete(rpc_get_pdu(rpc), NFS_STATUSX(rpc_status, res));
 
-    if (cookie_gap) {
+    /*
+     * "get_seq_last_cookie() == 0" is a common case when we purge the dircache
+     * if it grows beyond the configured limit. In that case all subsequent
+     * calls will see a cookie_gap and flood the logs.
+     */
+    if (cookie_gap && (dircache_handle->get_seq_last_cookie() != 0)) {
         AZLogWarn("[{}] readdirplus_callback: GAP in cookie requested ({} -> {})",
                   dir_ino, dircache_handle->get_seq_last_cookie(),
                   task->rpc_api->readdir_task.get_offset());


### PR DESCRIPTION
also limit single dir cache to not more than half the global max