### PR TITLE
adds support for OracleLinux

### DIFF
--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -144,7 +144,7 @@ ensure_pkg()
             exit 1
         fi
         apt=1
-    elif [ "$distro" == "centos" -o "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" ]; then
+    elif [ "$distro" == "centos" -o "$distro" == "rocky" -o "$distro" == "rhel" -o "$distro" == "mariner" -o "$distro" == "ol" ]; then
         use_dnf_or_yum
         check_update_opt=" --refresh"
         $yum -y check-update $check_update_opt >/dev/null 2>&1


### PR DESCRIPTION
OracleLinux is a wrapper of Redhat. Tested and verifed.

Fixes issue: https://github.com/Azure/AZNFS-mount/issues/148