### PR TITLE
Adding shutdown argument to invalidate_cache()

### DIFF
--- a/turbonfs/src/file_cache.cpp
+++ b/turbonfs/src/file_cache.cpp
@@ -2703,6 +2703,9 @@ void bytes_chunk_cache::clear_nolock(bool shutdown)
      * Since bytes_chunk_cache::get() increases the inuse count of all membufs
      * returned, and it does that while holding the bytes_chunk_cache::lock, we
      * can safely remove from chunkmap iff inuse/dirty/locked are not set.
+     *
+     * When shutdown is true we don't expect any of the above membuf types to
+     * be present, so we assert.
      */
     const uint64_t start_size = chunkmap.size();
 


### PR DESCRIPTION
This allows the following cases:

1. purge_now=false, shutdown=false: Don't purge now, but on next scan()
2. purge_now=true, shutdown=false: Purge now, but skip inuse and dirty membufs.
3. purge_now=true, shutdown=true: Purge now, forcing purge for inuse and dirty membufs too, they should not exist and hence we assert for them.
4. purge_now=false, shutdown=true: Invalid call

(cherry picked from commit b9a07bf9a85f5f4a0014898d5483b81ba8cd2bf3)