### PR TITLE
[spec] fix provides

### DIFF
--- a/packaging/aznfs/RPM/aznfs.spec
+++ b/packaging/aznfs/RPM/aznfs.spec
@@ -11,6 +11,9 @@ Recommends: build-essential
 Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools
 %endif
 
+# The included libraries should not be provided to the system as a whole
+%global __provides_exclude_from ^/opt/microsoft/aznfs/libs/.*\\.so.*$
+
 %description
 Mount helper program for Azure Blob NFS mounts, providing a secure communication channel for Azure File NFS mounts, and supporting the Turbo NFS client
 


### PR DESCRIPTION
The RPMs provided at `packages.microsoft.com/rhel/8/prod` have a `Provides` section that include glibc and other system libraries that are inappropriate and confuse package dependency evaluators. Remove those superfluous `Provides` entries.

Note: I have not been able to build the package directly, so hoping the CI pipeline will do so - looks like there is a build target.