### PR TITLE
[BUG][MAIN] update issue with package dependency eval.

### DIFF
--- a/packaging/aznfs/RPM/aznfs.spec
+++ b/packaging/aznfs/RPM/aznfs.spec
@@ -11,6 +11,9 @@ Recommends: build-essential
 Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools
 %endif
 
+# The included libraries should not be provided to the system as a whole
+%global __provides_exclude_from ^/opt/microsoft/aznfs/libs/.*\\.so.*$
+
 %description
 Mount helper program for Azure Blob NFS mounts, providing a secure communication channel for Azure File NFS mounts, and supporting the Turbo NFS client
 


### PR DESCRIPTION
**[root@palashvij-nfsv3mhRedhat8EU2 palashvij-nfsv3mhRedhat8EU2]# rpm -q --provide**                                                                                                                                                             s aznfs
aznfs = 3.0.3-1
aznfs(x86-64) = 3.0.3-1
ld-linux-x86-64.so.2()(64bit)
ld-linux-x86-64.so.2(GLIBC_2.2.5)(64bit)
ld-linux-x86-64.so.2(GLIBC_2.3)(64bit)
ld-linux-x86-64.so.2(GLIBC_2.34)(64bit)
ld-linux-x86-64.so.2(GLIBC_2.35)(64bit)
ld-linux-x86-64.so.2(GLIBC_2.4)(64bit)
ld-linux-x86-64.so.2(GLIBC_PRIVATE)(64bit)
libc.so.6()(64bit)
libc.so.6(GLIBC_2.10)(64bit)
libc.so.6(GLIBC_2.11)(64bit)
libc.so.6(GLIBC_2.12)(64bit)
libc.so.6(GLIBC_2.13)(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.15)(64bit)
libc.so.6(GLIBC_2.16)(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libc.so.6(GLIBC_2.18)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.2.6)(64bit)
libc.so.6(GLIBC_2.22)(64bit)
libc.so.6(GLIBC_2.23)(64bit)
libc.so.6(GLIBC_2.24)(64bit)
libc.so.6(GLIBC_2.25)(64bit)
libc.so.6(GLIBC_2.26)(64bit)
libc.so.6(GLIBC_2.27)(64bit)
libc.so.6(GLIBC_2.28)(64bit)
libc.so.6(GLIBC_2.29)(64bit)
libc.so.6(GLIBC_2.3)(64bit)
libc.so.6(GLIBC_2.3.2)(64bit)
libc.so.6(GLIBC_2.3.3)(64bit)
libc.so.6(GLIBC_2.3.4)(64bit)
libc.so.6(GLIBC_2.30)(64bit)
libc.so.6(GLIBC_2.31)(64bit)
libc.so.6(GLIBC_2.32)(64bit)
libc.so.6(GLIBC_2.33)(64bit)
libc.so.6(GLIBC_2.34)(64bit)
libc.so.6(GLIBC_2.35)(64bit)
libc.so.6(GLIBC_2.36)(64bit)
libc.so.6(GLIBC_2.38)(64bit)
libc.so.6(GLIBC_2.39)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.5)(64bit)
libc.so.6(GLIBC_2.6)(64bit)
libc.so.6(GLIBC_2.7)(64bit)
libc.so.6(GLIBC_2.8)(64bit)
libc.so.6(GLIBC_2.9)(64bit)
libc.so.6(GLIBC_ABI_DT_RELR)(64bit)
libc.so.6(GLIBC_PRIVATE)(64bit)
libdl.so.2()(64bit)
libdl.so.2(GLIBC_2.2.5)(64bit)
libdl.so.2(GLIBC_2.3.3)(64bit)
libdl.so.2(GLIBC_2.3.4)(64bit)
libffi.so.8()(64bit)
libffi.so.8(LIBFFI_BASE_8.0)(64bit)
libffi.so.8(LIBFFI_CLOSURE_8.0)(64bit)
libffi.so.8(LIBFFI_COMPLEX_8.0)(64bit)
libffi.so.8(LIBFFI_GO_CLOSURE_8.0)(64bit)
libm.so.6()(64bit)
libm.so.6(GLIBC_2.15)(64bit)
libm.so.6(GLIBC_2.18)(64bit)
libm.so.6(GLIBC_2.2.5)(64bit)
libm.so.6(GLIBC_2.23)(64bit)
libm.so.6(GLIBC_2.24)(64bit)
libm.so.6(GLIBC_2.25)(64bit)
libm.so.6(GLIBC_2.26)(64bit)
libm.so.6(GLIBC_2.27)(64bit)
libm.so.6(GLIBC_2.28)(64bit)
libm.so.6(GLIBC_2.29)(64bit)
libm.so.6(GLIBC_2.31)(64bit)
libm.so.6(GLIBC_2.32)(64bit)
libm.so.6(GLIBC_2.35)(64bit)
libm.so.6(GLIBC_2.38)(64bit)
libm.so.6(GLIBC_2.39)(64bit)
libm.so.6(GLIBC_2.4)(64bit)
libp11-kit.so.0()(64bit)
libp11-kit.so.0(LIBP11_KIT_1.0)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.11)(64bit)
libpthread.so.0(GLIBC_2.12)(64bit)
libpthread.so.0(GLIBC_2.18)(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libpthread.so.0(GLIBC_2.2.6)(64bit)
libpthread.so.0(GLIBC_2.28)(64bit)
libpthread.so.0(GLIBC_2.3.2)(64bit)
libpthread.so.0(GLIBC_2.3.3)(64bit)
libpthread.so.0(GLIBC_2.3.4)(64bit)
libpthread.so.0(GLIBC_2.30)(64bit)
libpthread.so.0(GLIBC_2.31)(64bit)
libpthread.so.0(GLIBC_2.4)(64bit)
libunistring.so.5()(64bit)
