### PR TITLE
Allow watchdog to clean up timed-out waiting mounts

### DIFF
--- a/src/aznfswatchdogv4
+++ b/src/aznfswatchdogv4
@@ -320,9 +320,15 @@ process_nfsv4_mounts()
         #
         if ! echo "$findmnt" | grep "$accept_port" >/dev/null; then
             vecho "findmnt shows no mount for accept_port=$accept_port (line=[$line])"
-            if is_nfs_server_active_for_target "$LOCALHOST" "$accept_port"; then
-                pecho "NFS server entry still active for $LOCALHOST:$accept_port; skipping cleanup for [$line]."
-                continue
+
+            # Some k8s pods may still hold mount namespace refs even after the
+            # host mount is gone. Skip cleanup if kernel NFS server refs are
+            # still active. For waiting/failed entries, cleanup to kill stunnel.
+            if [ "$l_status" == "mounted" ]; then
+                if is_nfs_server_active_for_target "$LOCALHOST" "$accept_port"; then
+                    pecho "NFS server entry still active for $LOCALHOST:$accept_port; skipping cleanup for [$line]."
+                    continue
+                fi
             fi
 
             pecho "No mounted shares for host $l_ip with accept port $accept_port, deleting from ${MOUNTMAPv4} [$line]."


### PR DESCRIPTION
When a new NFSv4 mount is not progressing and its timeout (180s) has expired, the watchdog should clean up stunnel so that further mounts can succeed.

Previously, the NFS server refs guard in /proc/fs/nfsfs/servers blocked cleanup for all entries regardless of status, preventing recovery. Now the guard is only applied to mounted entries where k8s pods may still hold mount namespace refs. 'waiting' entries with expired timeouts bypass the guard so stunnel can be restarted.


Cherry pick from main branch: https://github.com/Azure/AZNFS-mount/pull/295