### PR TITLE
[CP release/3.0] Add Ubuntu 26.04 LTS (resolute) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the watchdog process restarts it.
 
 AZNFS is supported on following Linux distros:
 
-- Ubuntu (18.04 LTS, 20.04 LTS, 22.04 LTS)
+- Ubuntu (18.04 LTS, 20.04 LTS, 22.04 LTS, 26.04 LTS)
 - Centos7, Centos8
 - RedHat7, RedHat8, RedHat9
 - Rocky8, Rocky9

--- a/packages.csv
+++ b/packages.csv
@@ -8,6 +8,8 @@ Ubuntu-22.04,aznfsDeb,microsoft-ubuntu-jammy-prod-apt,jammy
 Ubuntu-22.04,aznfsArm,microsoft-ubuntu-jammy-prod-apt,jammy
 Ubuntu-24.04,aznfsDeb,microsoft-ubuntu-noble-prod-apt,noble
 Ubuntu-24.04,aznfsArm,microsoft-ubuntu-noble-prod-apt,noble
+Ubuntu-26.04,aznfsDeb,microsoft-ubuntu-resolute-prod-apt,resolute
+Ubuntu-26.04,aznfsArm,microsoft-ubuntu-resolute-prod-apt,resolute
 RHEL-7.3,aznfsRpmStunnel,microsoft-rhel7.3-prod-yum,
 RHEL-7.3,aznfsArcRpmStunnel,microsoft-rhel7.3-prod-yum,
 RHEL-7.0,aznfsRpmStunnel,microsoft-rhel7.0-prod-yum,


### PR DESCRIPTION
PMC repo verified live: dists/resolute/Release present, architectures amd64/arm64, component=main. No pipeline change needed; PMC 2026 auto re-sign handles the CP-450779 -> CP-500207 key transition for 25.10+ Ubuntu repos.