### PR TITLE
Turbo acl bug fix

### DIFF
--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2120,6 +2120,29 @@ public:
         return nfs_get_rpc_context(get_nfs_context());
     }
 
+    /**
+     * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid.
+     *
+     * The FUSE daemon runs as root, so libnfs defaults to uid=0/gid=0
+     * in the RPC AUTH_UNIX header. With root_squash enabled on the
+     * server, this causes ALL operations to be squashed to nobody.
+     *
+     * This must be called before the rpc_nfs3_*_task() call so that
+     * rpc_allocate_pdu() picks up the correct AUTH credentials.
+     * Thread safety: nfs_set_uid/gid internally calls rpc_set_uid_gid
+     * which replaces rpc->auth. The rpc_mutex inside libnfs protects
+     * the auth update and PDU allocation atomically.
+     */
+    void set_caller_credentials()
+    {
+        const fuse_ctx *ctx = fuse_req_ctx(get_fuse_req());
+        if (ctx) {
+            struct nfs_context *nfs = get_nfs_context();
+            nfs_set_uid(nfs, ctx->uid);
+            nfs_set_gid(nfs, ctx->gid);
+        }
+    }
+
     nfs_client *get_client() const
     {
         assert (client != nullptr);

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2155,10 +2155,15 @@ public:
             struct nfs_context *nfs = get_nfs_context();
             nfs_set_uid(nfs, ctx->uid);
             nfs_set_gid(nfs, ctx->gid);
-            
-            /* Set supplementary groups for full access control */
+
+            /*
+             * Always set group vector to avoid stale supplementary groups
+             * leaking across requests sharing the same nfs context.
+             */
             if (ctx->ngroups > 0 && ctx->groups) {
                 nfs_set_groups(nfs, ctx->ngroups, ctx->groups);
+            } else {
+                nfs_set_groups(nfs, 0, nullptr);
             }
         }
     }

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2121,7 +2121,7 @@ public:
     }
 
     /**
-     * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid.
+     * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid and groups.
      *
      * The FUSE daemon runs as root, so libnfs defaults to uid=0/gid=0
      * in the RPC AUTH_UNIX header. With root_squash enabled on the
@@ -2129,6 +2129,7 @@ public:
      *
      * This must be called before the rpc_nfs3_*_task() call so that
      * rpc_allocate_pdu() picks up the correct AUTH credentials.
+     * Includes supplementary group IDs for proper group-based access control.
      *
      * For child/backend tasks where get_fuse_req() is null (for example
      * READ/WRITE backend tasks), we inherit the request context from the
@@ -2154,6 +2155,11 @@ public:
             struct nfs_context *nfs = get_nfs_context();
             nfs_set_uid(nfs, ctx->uid);
             nfs_set_gid(nfs, ctx->gid);
+            
+            /* Set supplementary groups for full access control */
+            if (ctx->ngroups > 0 && ctx->groups) {
+                nfs_set_groups(nfs, ctx->ngroups, ctx->groups);
+            }
         }
     }
 

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2129,13 +2129,27 @@ public:
      *
      * This must be called before the rpc_nfs3_*_task() call so that
      * rpc_allocate_pdu() picks up the correct AUTH credentials.
+     *
+     * For child/backend tasks where get_fuse_req() is null (for example
+     * READ/WRITE backend tasks), we inherit the request context from the
+     * parent task so each RPC still carries the correct caller identity.
      * Thread safety: nfs_set_uid/gid internally calls rpc_set_uid_gid
      * which replaces rpc->auth. The rpc_mutex inside libnfs protects
      * the auth update and PDU allocation atomically.
      */
     void set_caller_credentials()
     {
-        const fuse_ctx *ctx = fuse_req_ctx(get_fuse_req());
+        fuse_req *req = get_fuse_req();
+
+        if ((req == nullptr) && rpc_api && rpc_api->parent_task) {
+            req = rpc_api->parent_task->get_fuse_req();
+        }
+
+        if (req == nullptr) {
+            return;
+        }
+
+        const fuse_ctx *ctx = fuse_req_ctx(req);
         if (ctx) {
             struct nfs_context *nfs = get_nfs_context();
             nfs_set_uid(nfs, ctx->uid);

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -1568,6 +1568,7 @@ void rpc_task::issue_write_rpc()
 
     do {
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
 
         if (rpc_nfs3_writev_task(get_rpc_ctx(),
@@ -4136,6 +4137,7 @@ static void read_callback(
                  *       as we are holding all the needed locks and refs.
                  */
                 rpc_retry = false;
+                child_tsk->set_caller_credentials();
                 child_tsk->get_stats().on_rpc_issue();
                 if (rpc_nfs3_read_task(
                         child_tsk->get_rpc_ctx(),
@@ -4414,6 +4416,7 @@ void rpc_task::read_from_server(struct bytes_chunk &bc)
                    inode->get_fuse_ino(), args.offset, args.count);
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_read_task(
                 get_rpc_ctx(), /* This round robins request across connections */

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -1076,6 +1076,7 @@ void rpc_task::issue_commit_rpc()
 
     do {
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
 
         if (rpc_nfs3_commit_task(get_rpc_ctx(),
@@ -2654,6 +2655,7 @@ void rpc_task::run_lookup()
          *       caller. Since callback can free the task, it's not safe to
          *       access the task object after making the libnfs call.
          */
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_lookup_task(get_rpc_ctx(), lookup_callback, &args,
                                  this) == NULL) {
@@ -2685,6 +2687,7 @@ void rpc_task::run_access()
         args.access = rpc_api->access_task.get_mask();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_access_task(get_rpc_ctx(), access_callback, &args,
                                         this) == NULL) {
@@ -2898,6 +2901,7 @@ void rpc_task::run_getattr()
         args.object = inode->get_fh();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_getattr_task(get_rpc_ctx(), getattr_callback, &args,
                                   this) == NULL) {
@@ -2928,6 +2932,7 @@ void rpc_task::run_statfs()
         args.fsroot = get_client()->get_nfs_inode_from_ino(ino)->get_fh();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_fsstat_task(get_rpc_ctx(), statfs_callback, &args,
                                  this) == NULL) {
@@ -3233,6 +3238,7 @@ void rpc_task::run_readlink()
         args.symlink = get_client()->get_nfs_inode_from_ino(ino)->get_fh();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_readlink_task(get_rpc_ctx(),
                                           readlink_callback,
@@ -5519,6 +5525,7 @@ void rpc_task::fetch_readdir_entries_from_server()
         assert((args.cookie == 0) || (*(uint64_t *) args.cookieverf != 0));
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_readdir_task(get_rpc_ctx(),
                                   readdir_callback,
@@ -5585,6 +5592,7 @@ void rpc_task::fetch_readdirplus_entries_from_server()
         assert((args.cookie == 0) || (*(uint64_t *) args.cookieverf != 0));
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_readdirplus_task(get_rpc_ctx(),
                                       readdirplus_callback,

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -2970,6 +2970,7 @@ void rpc_task::run_create_file()
             rpc_api->create_task.get_gid();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_create_task(get_rpc_ctx(), createfile_callback, &args,
                                  this) == NULL) {
@@ -3015,6 +3016,7 @@ void rpc_task::run_mknod()
             rpc_api->mknod_task.get_gid();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_create_task(get_rpc_ctx(), mknod_callback, &args,
                                  this) == NULL) {
@@ -3054,6 +3056,7 @@ void rpc_task::run_mkdir()
         args.attributes.gid.set_gid3_u.gid = rpc_api->mkdir_task.get_gid();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_mkdir_task(get_rpc_ctx(), mkdir_callback, &args,
                                 this) == NULL) {
@@ -3085,6 +3088,7 @@ void rpc_task::run_unlink()
         args.object.name = (char*) rpc_api->unlink_task.get_file_name();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_remove_task(get_rpc_ctx(),
                                  unlink_callback, &args, this) == NULL) {
@@ -3117,6 +3121,7 @@ void rpc_task::run_rmdir()
         args.object.name = (char*) rpc_api->rmdir_task.get_dir_name();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_rmdir_task(get_rpc_ctx(),
                                 rmdir_callback, &args, this) == NULL) {
@@ -3157,6 +3162,7 @@ void rpc_task::run_symlink()
             rpc_api->symlink_task.get_gid();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_symlink_task(get_rpc_ctx(),
                                          symlink_callback,
@@ -3193,6 +3199,7 @@ void rpc_task::run_rename()
         args.to.name = (char*) rpc_api->rename_task.get_newname();
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_rename_task(get_rpc_ctx(),
                                         rename_callback,
@@ -3348,6 +3355,7 @@ void rpc_task::run_setattr()
         }
 
         rpc_retry = false;
+        set_caller_credentials();
         stats.on_rpc_issue();
         if (rpc_nfs3_setattr_task(get_rpc_ctx(), setattr_callback, &args,
                                   this) == NULL) {


### PR DESCRIPTION
Since the turbo client runs as a FUSE demon, it has a uid=0. When root squash is enabled, even though sattr3 has the correct uid/gid, it is not honored and the uid used is 0. To fix this i have called the setuid and setguid functions before each RPC dispatch