### PR TITLE
turbonfs: remove GnuTLS dependency, non-TLS only

### DIFF
--- a/generate_package.sh
+++ b/generate_package.sh
@@ -167,7 +167,9 @@ if [ "${BUILD_TYPE}" == "Debug" ]; then
     INSECURE_AUTH_FOR_DEVTEST=ON
 else
     PARANOID=OFF
-    INSECURE_AUTH_FOR_DEVTEST=OFF
+    # TLS support has been removed from libnfs, so AZAUTH is always sent over
+    # the non-TLS connection, which requires this to be ON.
+    INSECURE_AUTH_FOR_DEVTEST=ON
 fi
 
 # vcpkg required env variable VCPKG_FORCE_SYSTEM_BINARIES to be set for arm64.

--- a/package.sh
+++ b/package.sh
@@ -243,7 +243,9 @@ if [ "${BUILD_TYPE}" == "Debug" ]; then
     INSECURE_AUTH_FOR_DEVTEST=ON
 else
     PARANOID=OFF
-    INSECURE_AUTH_FOR_DEVTEST=OFF
+    # TLS support has been removed from libnfs, so AZAUTH is always sent over
+    # the non-TLS connection, which requires this to be ON.
+    INSECURE_AUTH_FOR_DEVTEST=ON
 fi
 
 # vcpkg required env variable VCPKG_FORCE_SYSTEM_BINARIES to be set for arm64.

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -24,7 +24,7 @@ option(ENABLE_NON_AZURE_NFS "Enable support for general NFS servers" OFF)
 option(ENABLE_CHATTY "Enable super verbose logs" OFF)
 option(ENABLE_TCMALLOC "Use tcmalloc for malloc/free/new/delete" OFF)
 option(ENABLE_JEMALLOC "Use jemalloc for malloc/free/new/delete" ON)
-option(ENABLE_INSECURE_AUTH_FOR_DEVTEST "Enable AZAUTH for non-TLS connections" OFF)
+option(ENABLE_INSECURE_AUTH_FOR_DEVTEST "Enable AZAUTH for non-TLS connections" ON)
 #
 # Builds that make it to customers need to be extra careful about any unnecessary
 # logging. Some warning logs we have in our code are to attract developer

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -205,21 +205,6 @@ add_custom_command(
 add_custom_target(libfuse ALL DEPENDS ${fuse3_LIBRARY})
 
 #
-# We need GnuTLS for secure libnfs transport.
-#
-find_package(GnuTLS "3.4.6" QUIET)
-if(NOT GNUTLS_FOUND)
-    message(STATUS "GnuTLS not found, trying to install gnutls-dev!")
-    execute_process(COMMAND sudo apt install -y gnutls-dev
-                    RESULT_VARIABLE GNUTLS_INSTALL_RESULT)
-    if(NOT GNUTLS_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install gnutls-dev failed with ${GNUTLS_INSTALL_RESULT}, try installing gnutls-dev manually and then run cmake again")
-    else()
-        find_package(GnuTLS "3.4.6" REQUIRED)
-    endif()
-endif()
-
-#
 # Find tcmalloc and if not found try to install.
 #
 if(ENABLE_TCMALLOC)
@@ -377,50 +362,6 @@ target_compile_options(${CMAKE_PROJECT_NAME}
                        PRIVATE -Werror
                        )
 
-#
-# Libraries for statically linking gnutls.
-# libp11-kit and libunistring do not have a static version available, so we are
-# forced to use the shared version and bundle it.
-#
-set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
-
-find_library(GNUTLS_STATIC_LIB libgnutls.a REQUIRED)
-#
-# arm64 libgnutls.a has multiple definitions for some symbols exported by
-# libcrypto.a. The libcrypto.a object has some more symbols which are needed,
-# so we delete the offending object from libgnutls.a before linking.
-#
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-execute_process(
-	COMMAND bash -c "cp -vf ${GNUTLS_STATIC_LIB} /tmp/gnutls.a; ar dv /tmp/gnutls.a aes-aarch64.o"
-	COMMAND_ERROR_IS_FATAL ANY)
-set(GNUTLS_STATIC_LIB /tmp/gnutls.a)
-endif()
-
-find_library(HOGWEED_STATIC_LIB libhogweed.a REQUIRED)
-find_library(NETTLE_STATIC_LIB libnettle.a REQUIRED)
-find_library(TASN1_STATIC_LIB libtasn1.a REQUIRED)
-find_library(IDN2_STATIC_LIB libidn2.a REQUIRED)
-find_library(GMP_STATIC_LIB libgmp.a REQUIRED)
-set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
-find_library(P11_KIT_SHARED_LIB libp11-kit.so REQUIRED)
-find_library(UNISTRING_SHARED_LIB NAMES
-             libunistring.so
-             libunistring.so.5
-             libunistring.so.2
-             REQUIRED)
-
-set(GNUTLS_ALL_LIBRARIES
-    ${GNUTLS_STATIC_LIB}
-    ${HOGWEED_STATIC_LIB}
-    ${NETTLE_STATIC_LIB}
-    ${TASN1_STATIC_LIB}
-    ${IDN2_STATIC_LIB}
-    ${GMP_STATIC_LIB}
-    ${P11_KIT_SHARED_LIB}
-    ${UNISTRING_SHARED_LIB})
-message(STATUS "Using gnutls libraries: ${GNUTLS_ALL_LIBRARIES}")
-
 # All libraries.
 target_link_libraries(${CMAKE_PROJECT_NAME}
                       -static-libgcc -static-libstdc++
@@ -429,8 +370,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
                       dl
                       pthread
                       nfs
-                      # GNUTLS libraries are needed by static libnfs.
-                      ${GNUTLS_ALL_LIBRARIES}
                       yaml-cpp
                       spdlog
                       Azure::azure-identity

--- a/turbonfs/build.sh
+++ b/turbonfs/build.sh
@@ -33,7 +33,9 @@ if [ "$BUILD_TYPE" == "Debug" ]; then
 else
     JEMALLOC=ON
     PARANOID=OFF
-    INSECURE_AUTH_FOR_DEVTEST=OFF
+    # TLS support has been removed from libnfs, so AZAUTH is always sent over
+    # the non-TLS connection, which requires this to be ON.
+    INSECURE_AUTH_FOR_DEVTEST=ON
 fi
 
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \

--- a/turbonfs/inc/aznfsc.h
+++ b/turbonfs/inc/aznfsc.h
@@ -247,7 +247,7 @@ typedef struct aznfsc_cfg
     // Fuse max_idle_threads config value.
     int fuse_max_idle_threads = -1;
 
-    // Whether to use TLS or not.
+    // Transport security; only "none" is supported (TLS support removed).
     const char *xprtsec = nullptr;
 
     // Whether to disable OOM killing for the aznfsclient process.

--- a/turbonfs/inc/nfs_internal.h
+++ b/turbonfs/inc/nfs_internal.h
@@ -32,8 +32,8 @@ struct mount_options
     const int nfs_port;
 
     /*
-     * Option to use transport security (TLS), it takes following values:
-     * tls: use TLS encryption.
+     * Transport security option. Only "none" is supported since RPC-with-TLS
+     * support (and its GnuTLS dependency) has been removed.
      * none: do not use TLS encryption.
      */
     const std::string xprtsec;

--- a/turbonfs/inc/util.h
+++ b/turbonfs/inc/util.h
@@ -78,7 +78,11 @@ bool is_valid_cloud_suffix(const std::string& cloud_suffix)
 static inline
 bool is_valid_xprtsec(const std::string& xprtsec)
 {
-    return (xprtsec == "tls" || xprtsec == "none");
+    /*
+     * Only non-TLS transport is supported. TLS support (and its gnutls
+     * dependency) has been removed.
+     */
+    return (xprtsec == "none");
 }
 
 static inline

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -12,7 +12,7 @@
 # account name, e.g., "myaccount-secondary".
 #
 account: nfsv3acc1bl2prdev13a
-container: testcont
+container: nfsv3test
 
 #cloud_suffix: blob.core.windows.net
 cloud_suffix: blob.preprod.core.windows.net
@@ -62,7 +62,7 @@ sys.nodrc.create_exist_as_success: true
 #
 
 # valid range: [1, 256]
-nconnect: 96
+nconnect: 1
 
 # valid range: [100, 6000]
 timeo: 600
@@ -203,9 +203,10 @@ oom_kill_disable: true
 auth: false
 
 #
-# Option controlling transport security, takes following values:
+# Option controlling transport security. Only "none" is supported.
+# RPC-with-TLS support (and its GnuTLS dependency) has been removed, so the
+# transport is always non-TLS.
 # none: do not use TLS encryption.
-# tls: use TLS encryption, as defined in RPC-with-TLS RFC 9289.
 #
 xprtsec: none
 

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -11,11 +11,11 @@
 # For accessing the secondary endpoint (RA-GRS), append "-secondary" to the
 # account name, e.g., "myaccount-secondary".
 #
-account: sjc22prdste06hnfsv3acc1
-container: nfsv3test
+account: nfsv3acc1bl2prdev13a
+container: testcont
 
 #cloud_suffix: blob.core.windows.net
-#cloud_suffix: blob.preprod.core.windows.net
+cloud_suffix: blob.preprod.core.windows.net
 #port: 2048
 
 #

--- a/turbonfs/sample-turbo-config.yaml
+++ b/turbonfs/sample-turbo-config.yaml
@@ -62,7 +62,7 @@ sys.nodrc.create_exist_as_success: true
 #
 
 # valid range: [1, 256]
-nconnect: 1
+nconnect: 96
 
 # valid range: [100, 6000]
 timeo: 600


### PR DESCRIPTION
## Summary

Remove the **GnuTLS** dependency from the turbonfs build so builds are not blocked on distros
where gnutls is not an allowed package (e.g. Azure Linux). The only supported transport is
non-TLS (`xprtsec=none`), and **AZAUTH (AzAuthNone) is always sent as the first RPC** over that
non-TLS connection.

This is the turbonfs/packaging side. The corresponding libnfs changes are in
linuxsmiths/libnfs#39.

## Changes

- **turbonfs/CMakeLists.txt**
  - Drop `find_package(GnuTLS)` and the static gnutls linking
    (`libgnutls`/`hogweed`/`nettle`/`tasn1`/`idn2`/`gmp`/`p11-kit`/`unistring`) — the binary no
    longer links gnutls.
  - Default `ENABLE_INSECURE_AUTH_FOR_DEVTEST` to **ON**.
- **turbonfs/inc/util.h**: `is_valid_xprtsec()` accepts only `none`.
- **turbonfs/build.sh, package.sh, generate_package.sh**: set
  `INSECURE_AUTH_FOR_DEVTEST=ON` for all build types (not just Debug).

## Why the flag is required for all builds

libnfs now has TLS removed, so AZAUTH is always sent over the non-TLS connection. That path is
gated by `ENABLE_INSECURE_AUTH_FOR_DEVTEST`, and libnfs bails out (static gate) if it is
disabled. Hence turbonfs must enable it for every build type — previously it was Debug-only.

## Runtime flow

```mermaid
sequenceDiagram
    participant C as aznfsclient (turbonfs)
    participant L as libnfs
    participant S as Blob NFS server (:2048)
    C->>L: nfs_set_auth_context(authtype=AzAuthNone) -> use_azauth=TRUE
    C->>L: nfs_mount()
    L->>S: TCP connect (non-TLS)
    L->>S: AZAUTH RPC (AzAuthNone)  (always first, over non-TLS)
    alt server has AzAuth enabled
        S-->>L: AZAUTH OK
        L->>S: MOUNT / NFS ops
        S-->>C: mounted (or MNT3ERR_NOENT if container missing)
    else server without AzAuth
        S-->>L: no response / reject
        L-->>C: "AzAuth not enabled/setup on server" diagnostic
    end
```

## Testing

- Full turbonfs build succeeds; `aznfsclient` links **no** gnutls
  (`ldd` shows only libuuid/libm/libc).
- AzAuth-enabled account: AzAuthNone accepted, proceeds to MOUNT (server responds).
- Non-AzAuth account: AZAUTH fails fast with a clear diagnostic.

> Depends on linuxsmiths/libnfs#39 (submodule pointer bump to be done once that merges).
