### PR TITLE
Add support for dynamic linking for azurelinux

### DIFF
--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -190,6 +190,7 @@ stages:
               PathtoPublish: $(Build.ArtifactStagingDirectory)
               artifactName: 'aznfs-temp'
 
+# TODO: add azurelinux later to release and publish stages post approvals 
   - stage: ReleaseArtifacts
     displayName: "Sign and Release Artifacts"
     jobs:

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -173,6 +173,58 @@ stages:
               PathtoPublish: $(Build.ArtifactStagingDirectory)
               artifactName: 'aznfs-temp'
 
+      - job: package_aznfs_azurelinux_arm64
+        displayName: Package and Release ${{ parameters.versionName }} for azurelinux arm64
+        pool:
+          name: 'aznfsazurelinuxpoolarm64'
+
+        steps:
+          - script: |
+              arch=$(uname -m)
+              echo "Building version ${{ parameters.versionName }} for $arch"
+              if [ "$arch" != "aarch64" ]; then
+                echo "Expected an aarch64 agent, but found $arch"
+                exit 1
+              fi
+            displayName: "Verify ARM64 Build Agent"
+
+          - checkout: self
+            path: azurelinux/AZNFS-mount
+            displayName: 'Checkout repository'
+
+          - script: |
+              echo "Installing prerequisites on Azure Linux..."
+              sudo tdnf update -y
+              sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+                gcc gcc-c++ make git curl unzip zip tar cmake \
+                zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+                libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
+                pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
+                kernel-headers kernel-devel autoconf automake libtool jemalloc-devel fuse3-devel
+            displayName: "Install prerequisites on Azure Linux"
+
+          - script: |
+              export RELEASE_NUMBER=${{ parameters.versionName }}
+              export STG_DIR=$(System.DefaultWorkingDirectory)
+              export SOURCE_DIR=$(System.DefaultWorkingDirectory)
+              export BUILD_TYPE=${{ parameters.buildType }}
+              export BUILD_MACHINE=azurelinux
+              chmod +x $SOURCE_DIR/generate_package.sh
+              $SOURCE_DIR/generate_package.sh
+            displayName: "Run Package Script"
+
+          - script: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/rpmazurelinuxarm64
+              cp -f $(System.DefaultWorkingDirectory)/azurelinux/root/rpmbuild/RPMS/aarch64/aznfs-${{ parameters.versionName }}-1.aarch64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpmazurelinuxarm64
+              echo "Listing Built Files..."
+              ls -R $(Build.ArtifactStagingDirectory)
+            displayName: "Copy RPM to Artifacts"
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              artifactName: 'aznfs-temp'
+
 # TODO: add azurelinux later to release and publish stages post approvals 
   - stage: ReleaseArtifacts
     displayName: "Sign and Release Artifacts"

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -99,7 +99,7 @@ stages:
                 zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
                 libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
                 pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-                kernel-headers kernel-devel autoconf automake libtool jemalloc-devel
+                kernel-headers kernel-devel autoconf automake libtool jemalloc-devel fuse3-devel
             displayName: "Install prerequisites on Azure Linux"
           
           # note: remove later.

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -117,7 +117,7 @@ stages:
               export SOURCE_DIR=$(System.DefaultWorkingDirectory)
               export BUILD_TYPE=${{ parameters.buildType }}
               export BUILD_MACHINE=azurelinux
-              chmod +x $SOURCE_DIR/generate_package.sh
+              chmod +x $SOURCE_DIR/generate_package.sh 
               $SOURCE_DIR/generate_package.sh
             displayName: "Run Package Script"
 
@@ -130,8 +130,8 @@ stages:
             displayName: "Debug: List directory structure"
 
           - script: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/rpm
-              cp -f $(System.DefaultWorkingDirectory)/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ parameters.versionName }}-1.x86_64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpm
+              mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/rpmazurelinux
+              cp -f $(System.DefaultWorkingDirectory)/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-${{ parameters.versionName }}-1.x86_64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpmazurelinux
               echo "Listing Built Files..."
               ls -R $(Build.ArtifactStagingDirectory)
             displayName: "Copy RPM to Artifacts"

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -81,7 +81,7 @@ stages:
               PathtoPublish: $(Build.ArtifactStagingDirectory)
               artifactName: 'aznfs-temp'
 
-      - job: package_aznfs_azurelinu_amd64
+      - job: package_aznfs_azurelinux_amd64
         displayName: Package and Release ${{ parameters.versionName }} for azurelinux
         pool:
           name: 'aznfsazurelinuxdemopool'   # Use your self-hosted agent
@@ -102,15 +102,6 @@ stages:
                 kernel-headers kernel-devel autoconf automake libtool jemalloc-devel fuse3-devel
             displayName: "Install prerequisites on Azure Linux"
           
-          # note: remove later.
-          - script: |
-              echo "=== Validating Build Environment ==="
-              gcc --version
-              cmake --version
-              tdnf --version
-              echo "Architecture: $(uname -m)"
-            displayName: "Validate build environment"
-
           - script: |
               export RELEASE_NUMBER=${{ parameters.versionName }}
               export STG_DIR=$(System.DefaultWorkingDirectory)
@@ -120,14 +111,6 @@ stages:
               chmod +x $SOURCE_DIR/generate_package.sh 
               $SOURCE_DIR/generate_package.sh
             displayName: "Run Package Script"
-
-          # note: remove later.
-          - script: |
-              echo "=== Directory Structure ==="
-              find $(System.DefaultWorkingDirectory) -name "*.rpm" -type f
-              echo "=== STG_DIR Contents ==="
-              ls -la $(System.DefaultWorkingDirectory)
-            displayName: "Debug: List directory structure"
 
           - script: |
               mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/rpmazurelinux

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -114,7 +114,7 @@ stages:
           - script: |
               export RELEASE_NUMBER=${{ parameters.versionName }}
               export STG_DIR=$(System.DefaultWorkingDirectory)
-              export SOURCE_DIR=$(System.DefaultWorkingDirectory)/azurelinux
+              export SOURCE_DIR=$(System.DefaultWorkingDirectory)
               export BUILD_TYPE=${{ parameters.buildType }}
               export BUILD_MACHINE=azurelinux
               chmod +x $SOURCE_DIR/generate_package.sh

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -438,6 +438,7 @@ stages:
               chmod 755 $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/*/*.rpm
               rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/*.md
               rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/*/*.md
+              rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/rpmazurelinux $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/rpmazurelinuxarm64
               mv $(Build.ArtifactStagingDirectory)/aznfs-temp/* $(Build.ArtifactStagingDirectory)/
               rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/
             displayName: 'Make Artifacts executable'

--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -55,6 +55,7 @@ stages:
               export STG_DIR=$(System.DefaultWorkingDirectory)
               export SOURCE_DIR=$(System.DefaultWorkingDirectory)
               export BUILD_TYPE=${{ parameters.buildType }}
+              export BUILD_MACHINE=ubuntu
               chmod +x $SOURCE_DIR/generate_package.sh
               $SOURCE_DIR/generate_package.sh
             displayName: "Run Package Script"
@@ -74,6 +75,66 @@ stages:
               echo "Listing Built Files..."
               ls -R $(Build.ArtifactStagingDirectory)
             displayName: "List Build Outputs"
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: $(Build.ArtifactStagingDirectory)
+              artifactName: 'aznfs-temp'
+
+      - job: package_aznfs_azurelinu_amd64
+        displayName: Package and Release ${{ parameters.versionName }} for azurelinux
+        pool:
+          name: 'aznfsazurelinuxdemopool'   # Use your self-hosted agent
+
+        steps:
+          - checkout: self
+            path: azurelinux/AZNFS-mount
+            displayName: 'Checkout repository'
+
+          - script: |
+              echo "Installing prerequisites on Azure Linux..."
+              sudo tdnf update -y
+              sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+                gcc gcc-c++ make git curl unzip zip tar cmake \
+                zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+                libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
+                pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
+                kernel-headers kernel-devel autoconf automake libtool jemalloc-devel
+            displayName: "Install prerequisites on Azure Linux"
+          
+          # note: remove later.
+          - script: |
+              echo "=== Validating Build Environment ==="
+              gcc --version
+              cmake --version
+              tdnf --version
+              echo "Architecture: $(uname -m)"
+            displayName: "Validate build environment"
+
+          - script: |
+              export RELEASE_NUMBER=${{ parameters.versionName }}
+              export STG_DIR=$(System.DefaultWorkingDirectory)
+              export SOURCE_DIR=$(System.DefaultWorkingDirectory)/azurelinux
+              export BUILD_TYPE=${{ parameters.buildType }}
+              export BUILD_MACHINE=azurelinux
+              chmod +x $SOURCE_DIR/generate_package.sh
+              $SOURCE_DIR/generate_package.sh
+            displayName: "Run Package Script"
+
+          # note: remove later.
+          - script: |
+              echo "=== Directory Structure ==="
+              find $(System.DefaultWorkingDirectory) -name "*.rpm" -type f
+              echo "=== STG_DIR Contents ==="
+              ls -la $(System.DefaultWorkingDirectory)
+            displayName: "Debug: List directory structure"
+
+          - script: |
+              mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/rpm
+              cp -f $(System.DefaultWorkingDirectory)/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ parameters.versionName }}-1.x86_64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpm
+              echo "Listing Built Files..."
+              ls -R $(Build.ArtifactStagingDirectory)
+            displayName: "Copy RPM to Artifacts"
 
           - task: PublishBuildArtifacts@1
             inputs:
@@ -104,6 +165,7 @@ stages:
               export STG_DIR=$(System.DefaultWorkingDirectory)
               export SOURCE_DIR=$(System.DefaultWorkingDirectory)
               export BUILD_TYPE=${{ parameters.buildType }}
+              export BUILD_MACHINE=ubuntu
               chmod +x $SOURCE_DIR/generate_package.sh
               $SOURCE_DIR/generate_package.sh
             displayName: "Run Package Script"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -75,47 +75,46 @@ jobs:
         body: |
           New Test Release ${{ github.event.inputs.versionName }}
 
-  # NOTE: UNCOMMENT THIS JOB ONCE AZURE LINUX RUNNER IS CONNECTED
-  #
-  # package_mount_helper_azurelinux:
-  #   name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
-  #   runs-on: self-hosted
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: azurelinux
+  # NOTE: COMMENT THIS JOB IF AZURE LINUX RUNNER IS NOT CONNECTED  
+  package_mount_helper_azurelinux:
+    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
+    runs-on: self-hosted
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: azurelinux
 
-  #   - name: Install prerequisites on Azure Linux
-  #     run: |
-  #       sudo tdnf update -y
-  #       sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
-  #         gcc gcc-c++ make git curl unzip zip tar cmake \
-  #         zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
-  #         libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
-  #         pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-  #         kernel-headers kernel-devel autoconf automake libtool
+    - name: Install prerequisites on Azure Linux
+      run: |
+        sudo tdnf update -y
+        sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+          gcc gcc-c++ make git curl unzip zip tar cmake \
+          zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+          libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
+          pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
+          kernel-headers kernel-devel autoconf automake libtool
 
-  #   - name: Run Package.sh for azurelinux
-  #     run: |
-  #       export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
-  #       export STG_DIR=$GITHUB_WORKSPACE
-  #       export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
-  #       export BUILD_TYPE=${{ github.event.inputs.buildType }}
-  #       export BUILD_MACHINE=azurelinux
-  #       chmod +x $SOURCE_DIR/package.sh
-  #       $SOURCE_DIR/package.sh
+    - name: Run Package.sh for azurelinux
+      run: |
+        export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
+        export STG_DIR=$GITHUB_WORKSPACE
+        export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
+        export BUILD_TYPE=${{ github.event.inputs.buildType }}
+        export BUILD_MACHINE=azurelinux
+        chmod +x $SOURCE_DIR/package.sh
+        $SOURCE_DIR/package.sh
 
-  #   - name: Create Release (azurelinux)
-  #     uses: softprops/action-gh-release@v1
-  #     with:
-  #       name: Release ${{ github.event.inputs.versionName }}
-  #       tag_name: ${{ github.event.inputs.versionName }}
-  #       target_commitish: ${{ github.sha }}
-  #       files: |
-  #         ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
-  #       body: |
-  #         New Release ${{ github.event.inputs.versionName }}
+    - name: Create Release (azurelinux)
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release ${{ github.event.inputs.versionName }}
+        tag_name: ${{ github.event.inputs.versionName }}
+        target_commitish: ${{ github.sha }}
+        files: |
+          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
+        body: |
+          New Release ${{ github.event.inputs.versionName }}
 
   package_mount_helper_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ permissions:
   contents: write
 
 jobs:
-  package_mount_helper_amd64:
+  package_mount_helper_ubuntu_amd64:
     name: Package and Release ${{ github.event.inputs.versionName }} for amd64 (Test Release)
     runs-on: ubuntu-22.04
     steps:
@@ -76,7 +76,7 @@ jobs:
           New Test Release ${{ github.event.inputs.versionName }}
 
   # NOTE: COMMENT THIS JOB IF AZURE LINUX RUNNER IS NOT CONNECTED  
-  package_mount_helper_azurelinux:
+  package_mount_helper_azurelinux_amd64:
     name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
     runs-on: self-hosted
     steps:
@@ -116,7 +116,7 @@ jobs:
         body: |
           New Release ${{ github.event.inputs.versionName }}
 
-  package_mount_helper_arm64:
+  package_mount_helper_ubuntu_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)
     runs-on: ubuntu-22.04-arm
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -75,45 +75,47 @@ jobs:
         body: |
           New Test Release ${{ github.event.inputs.versionName }}
 
-  package_mount_helper_azurelinux:
-    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
-    runs-on: self-hosted
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: azurelinux
+  # NOTE: UNCOMMENT THIS JOB ONCE AZURE LINUX RUNNER IS CONNECTED
+  #
+  # package_mount_helper_azurelinux:
+  #   name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
+  #   runs-on: self-hosted
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+  #     with:
+  #       path: azurelinux
 
-    - name: Install prerequisites on Azure Linux
-      run: |
-        sudo tdnf update -y
-        sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
-          gcc gcc-c++ make git curl unzip zip tar cmake \
-          zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
-          libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
-          pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-          kernel-headers kernel-devel autoconf automake libtool
+  #   - name: Install prerequisites on Azure Linux
+  #     run: |
+  #       sudo tdnf update -y
+  #       sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+  #         gcc gcc-c++ make git curl unzip zip tar cmake \
+  #         zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+  #         libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
+  #         pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
+  #         kernel-headers kernel-devel autoconf automake libtool
 
-    - name: Run Package.sh for azurelinux
-      run: |
-        export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
-        export STG_DIR=$GITHUB_WORKSPACE
-        export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
-        export BUILD_TYPE=${{ github.event.inputs.buildType }}
-        export BUILD_MACHINE=azurelinux
-        chmod +x $SOURCE_DIR/package.sh
-        $SOURCE_DIR/package.sh
+  #   - name: Run Package.sh for azurelinux
+  #     run: |
+  #       export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
+  #       export STG_DIR=$GITHUB_WORKSPACE
+  #       export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
+  #       export BUILD_TYPE=${{ github.event.inputs.buildType }}
+  #       export BUILD_MACHINE=azurelinux
+  #       chmod +x $SOURCE_DIR/package.sh
+  #       $SOURCE_DIR/package.sh
 
-    - name: Create Release (azurelinux)
-      uses: softprops/action-gh-release@v1
-      with:
-        name: Release ${{ github.event.inputs.versionName }}
-        tag_name: ${{ github.event.inputs.versionName }}
-        target_commitish: ${{ github.sha }}
-        files: |
-          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
-        body: |
-          New Release ${{ github.event.inputs.versionName }}
+  #   - name: Create Release (azurelinux)
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       name: Release ${{ github.event.inputs.versionName }}
+  #       tag_name: ${{ github.event.inputs.versionName }}
+  #       target_commitish: ${{ github.sha }}
+  #       files: |
+  #         ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
+  #       body: |
+  #         New Release ${{ github.event.inputs.versionName }}
 
   package_mount_helper_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   package_mount_helper_ubuntu_amd64:
     name: Package and Release ${{ github.event.inputs.versionName }} for amd64 (Test Release)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check Version Number
       shell: bash
@@ -118,7 +118,7 @@ jobs:
 
   package_mount_helper_ubuntu_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     steps:
     - name: Check Version Number
       shell: bash

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
           zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
           libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
           pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-          kernel-headers kernel-devel autoconf automake libtool
+          kernel-headers kernel-devel autoconf automake libtool fuse3-devel
 
     - name: Run Package.sh for azurelinux
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   package_mount_helper_ubuntu_amd64:
     name: Package and Release ${{ github.event.inputs.versionName }} for amd64 (Test Release)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Version Number
       shell: bash
@@ -118,7 +118,7 @@ jobs:
 
   package_mount_helper_ubuntu_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
     - name: Check Version Number
       shell: bash

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -93,7 +93,7 @@ jobs:
           zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
           libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
           pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-          kernel-headers kernel-devel autoconf automake libtool fuse3-devel
+          kernel-headers kernel-devel autoconf automake libtool jemalloc-devel fuse3-devel
 
     - name: Run Package.sh for azurelinux
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -55,6 +55,7 @@ jobs:
         export STG_DIR=$GITHUB_WORKSPACE/amd64
         export SOURCE_DIR=$GITHUB_WORKSPACE/amd64
         export BUILD_TYPE=${{ github.event.inputs.buildType }}
+        export BUILD_MACHINE=ubuntu
         chmod +x $SOURCE_DIR/package.sh
         $SOURCE_DIR/package.sh
     - name: Create Test Release
@@ -73,6 +74,46 @@ jobs:
           ${{ github.workspace }}/amd64/tarball/aznfs-${{ github.event.inputs.versionName }}-1.x86_64.tar.gz
         body: |
           New Test Release ${{ github.event.inputs.versionName }}
+
+  package_mount_helper_azurelinux:
+    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
+    runs-on: self-hosted
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        path: azurelinux
+
+    - name: Install prerequisites on Azure Linux
+      run: |
+        sudo tdnf update -y
+        sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+          gcc gcc-c++ make git curl unzip zip tar cmake \
+          zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+          libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
+          pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
+          kernel-headers kernel-devel autoconf automake libtool
+
+    - name: Run Package.sh for azurelinux
+      run: |
+        export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
+        export STG_DIR=$GITHUB_WORKSPACE
+        export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
+        export BUILD_TYPE=${{ github.event.inputs.buildType }}
+        export BUILD_MACHINE=azurelinux
+        chmod +x $SOURCE_DIR/package.sh
+        $SOURCE_DIR/package.sh
+
+    - name: Create Release (azurelinux)
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Release ${{ github.event.inputs.versionName }}
+        tag_name: ${{ github.event.inputs.versionName }}
+        target_commitish: ${{ github.sha }}
+        files: |
+          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
+        body: |
+          New Release ${{ github.event.inputs.versionName }}
 
   package_mount_helper_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -75,11 +75,60 @@ jobs:
         body: |
           New Test Release ${{ github.event.inputs.versionName }}
 
-  # NOTE: COMMENT THIS JOB IF AZURE LINUX RUNNER IS NOT CONNECTED  
-  package_mount_helper_azurelinux_amd64:
-    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
+  # NOTE: UNCOMMENT THIS JOB IF THE AZURE LINUX AMD64 RUNNER IS CONNECTED
+  # package_mount_helper_azurelinux_amd64:
+  #   name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux
+  #   runs-on: self-hosted
+  #   steps:
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+  #     with:
+  #       path: azurelinux
+  #
+  #   - name: Install prerequisites on Azure Linux
+  #     run: |
+  #       sudo tdnf update -y
+  #       sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+  #         gcc gcc-c++ make git curl unzip zip tar cmake autoconf automake libtool \
+  #         zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+  #         libyaml-devel spdlog-devel nlohmann-json-devel jemalloc jemalloc-devel \
+  #         fuse3 fuse3-devel pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build \
+  #         binutils kernel-headers kernel-devel procps-ng conntrack-tools iptables \
+  #         bind-utils iproute util-linux nmap-ncat newt stunnel net-tools libasan
+  #
+  #   - name: Run Package.sh for azurelinux
+  #     run: |
+  #       export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
+  #       export STG_DIR=$GITHUB_WORKSPACE
+  #       export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
+  #       export BUILD_TYPE=${{ github.event.inputs.buildType }}
+  #       export BUILD_MACHINE=azurelinux
+  #       chmod +x $SOURCE_DIR/package.sh
+  #       $SOURCE_DIR/package.sh
+  #
+  #   - name: Create Release (azurelinux)
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       name: Release ${{ github.event.inputs.versionName }}
+  #       tag_name: ${{ github.event.inputs.versionName }}
+  #       target_commitish: ${{ github.sha }}
+  #       files: |
+  #         ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
+  #       body: |
+  #         New Release ${{ github.event.inputs.versionName }}
+
+  # NOTE: COMMENT THIS JOB IF THE AZURE LINUX ARM64 RUNNER IS NOT CONNECTED
+  package_mount_helper_azurelinux_arm64:
+    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux arm64
     runs-on: self-hosted
     steps:
+    - name: Verify ARM64 runner
+      run: |
+        if [ "$(uname -m)" != "aarch64" ]; then
+          echo "Expected an aarch64 runner, but found $(uname -m)"
+          exit 1
+        fi
+
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
@@ -89,11 +138,12 @@ jobs:
       run: |
         sudo tdnf update -y
         sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
-          gcc gcc-c++ make git curl unzip zip tar cmake \
+          gcc gcc-c++ make git curl unzip zip tar cmake autoconf automake libtool \
           zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
-          libyaml-devel spdlog-devel nlohmann-json-devel cmake make \
-          pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build binutils \
-          kernel-headers kernel-devel autoconf automake libtool jemalloc-devel fuse3-devel
+          libyaml-devel spdlog-devel nlohmann-json-devel jemalloc jemalloc-devel \
+          fuse3 fuse3-devel pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build \
+          binutils kernel-headers kernel-devel procps-ng conntrack-tools iptables \
+          bind-utils iproute util-linux nmap-ncat newt stunnel net-tools libasan
 
     - name: Run Package.sh for azurelinux
       run: |
@@ -105,14 +155,14 @@ jobs:
         chmod +x $SOURCE_DIR/package.sh
         $SOURCE_DIR/package.sh
 
-    - name: Create Release (azurelinux)
+    - name: Create Release (azurelinux arm64)
       uses: softprops/action-gh-release@v1
       with:
         name: Release ${{ github.event.inputs.versionName }}
         tag_name: ${{ github.event.inputs.versionName }}
         target_commitish: ${{ github.sha }}
         files: |
-          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/x86_64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.x86_64.rpm
+          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/aarch64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.aarch64.rpm
         body: |
           New Release ${{ github.event.inputs.versionName }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -117,54 +117,54 @@ jobs:
   #       body: |
   #         New Release ${{ github.event.inputs.versionName }}
 
-  # NOTE: COMMENT THIS JOB IF THE AZURE LINUX ARM64 RUNNER IS NOT CONNECTED
-  package_mount_helper_azurelinux_arm64:
-    name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux arm64
-    runs-on: self-hosted
-    steps:
-    - name: Verify ARM64 runner
-      run: |
-        if [ "$(uname -m)" != "aarch64" ]; then
-          echo "Expected an aarch64 runner, but found $(uname -m)"
-          exit 1
-        fi
-
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        path: azurelinux
-
-    - name: Install prerequisites on Azure Linux
-      run: |
-        sudo tdnf update -y
-        sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
-          gcc gcc-c++ make git curl unzip zip tar cmake autoconf automake libtool \
-          zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
-          libyaml-devel spdlog-devel nlohmann-json-devel jemalloc jemalloc-devel \
-          fuse3 fuse3-devel pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build \
-          binutils kernel-headers kernel-devel procps-ng conntrack-tools iptables \
-          bind-utils iproute util-linux nmap-ncat newt stunnel net-tools libasan
-
-    - name: Run Package.sh for azurelinux
-      run: |
-        export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
-        export STG_DIR=$GITHUB_WORKSPACE
-        export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
-        export BUILD_TYPE=${{ github.event.inputs.buildType }}
-        export BUILD_MACHINE=azurelinux
-        chmod +x $SOURCE_DIR/package.sh
-        $SOURCE_DIR/package.sh
-
-    - name: Create Release (azurelinux arm64)
-      uses: softprops/action-gh-release@v1
-      with:
-        name: Release ${{ github.event.inputs.versionName }}
-        tag_name: ${{ github.event.inputs.versionName }}
-        target_commitish: ${{ github.sha }}
-        files: |
-          ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/aarch64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.aarch64.rpm
-        body: |
-          New Release ${{ github.event.inputs.versionName }}
+  # NOTE: UNCOMMENT THIS JOB IF THE AZURE LINUX ARM64 RUNNER IS CONNECTED
+  # package_mount_helper_azurelinux_arm64:
+  #   name: Package and Release ${{ github.event.inputs.versionName }} for azurelinux arm64
+  #   runs-on: self-hosted
+  #   steps:
+  #   - name: Verify ARM64 runner
+  #     run: |
+  #       if [ "$(uname -m)" != "aarch64" ]; then
+  #         echo "Expected an aarch64 runner, but found $(uname -m)"
+  #         exit 1
+  #       fi
+  #
+  #   - name: Checkout repository
+  #     uses: actions/checkout@v3
+  #     with:
+  #       path: azurelinux
+  #
+  #   - name: Install prerequisites on Azure Linux
+  #     run: |
+  #       sudo tdnf update -y
+  #       sudo tdnf install -y glibc-static rpm-build perl perl-IPC-Cmd \
+  #         gcc gcc-c++ make git curl unzip zip tar cmake autoconf automake libtool \
+  #         zlib zlib-devel libuuid-devel gnutls gnutls-devel nfs-utils \
+  #         libyaml-devel spdlog-devel nlohmann-json-devel jemalloc jemalloc-devel \
+  #         fuse3 fuse3-devel pkgconf pkgconf-m4 pkgconf-pkg-config ninja-build \
+  #         binutils kernel-headers kernel-devel procps-ng conntrack-tools iptables \
+  #         bind-utils iproute util-linux nmap-ncat newt stunnel net-tools libasan
+  #
+  #   - name: Run Package.sh for azurelinux
+  #     run: |
+  #       export RELEASE_NUMBER=${{ github.event.inputs.versionName }}
+  #       export STG_DIR=$GITHUB_WORKSPACE
+  #       export SOURCE_DIR=$GITHUB_WORKSPACE/azurelinux
+  #       export BUILD_TYPE=${{ github.event.inputs.buildType }}
+  #       export BUILD_MACHINE=azurelinux
+  #       chmod +x $SOURCE_DIR/package.sh
+  #       $SOURCE_DIR/package.sh
+  #
+  #   - name: Create Release (azurelinux arm64)
+  #     uses: softprops/action-gh-release@v1
+  #     with:
+  #       name: Release ${{ github.event.inputs.versionName }}
+  #       tag_name: ${{ github.event.inputs.versionName }}
+  #       target_commitish: ${{ github.sha }}
+  #       files: |
+  #         ${{ github.workspace }}/azurelinux/root/rpmbuild/RPMS/aarch64/aznfs-azurelinux-${{ github.event.inputs.versionName }}-1.aarch64.rpm
+  #       body: |
+  #         New Release ${{ github.event.inputs.versionName }}
 
   package_mount_helper_ubuntu_arm64:
     name: Package and Release ${{ github.event.inputs.versionName }} for arm64 (Test Release)

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -67,21 +67,18 @@ generate_rpm_package()
 	# copy the aznfsclient config file.
 	cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
 
-	if [ "$rpm_dir" != "azurelinux" ]; then
-		# copy the aznfsclient binary.
-		cp -avf ${aznfsclient} ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
-	else
-		# Define the final target location for aznfsclient
-		aznfsclient_target="${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient"
+	# Common handling for aznfsclient binary copy across all distros.
+	# Define the source and destination for aznfsclient.
+	aznfsclient_src="${SOURCE_DIR}/turbonfs/build/aznfsclient"
+	aznfsclient_target="${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient"
 
-		# Copy the built aznfsclient binary to the target
-		cp -avf "${SOURCE_DIR}/turbonfs/build/aznfsclient" "${aznfsclient_target}"
+	# Copy the built aznfsclient binary to the target
+	cp -avf "${aznfsclient_src}" "${aznfsclient_target}"
 
-		# Optional: fail early if copy fails
-		if [ ! -f "${aznfsclient_target}" ]; then
-			echo "Error: aznfsclient failed to copy to ${aznfsclient_target}"
-			exit 1
-		fi
+	# Fail early if copy fails
+	if [ ! -f "${aznfsclient_target}" ]; then
+		echo "Error: aznfsclient failed to copy to ${aznfsclient_target}"
+		exit 1
 	fi
 
 	if [ "$rpm_dir" != "azurelinux" ]; then

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -33,7 +33,7 @@ generate_rpm_package()
 
 	# Overwrite rpm_pkg_dir in case of azurelinux.
 	if [ "$rpm_dir" == "azurelinux" ]; then
-		rpm_pkg_dir="${pkg_name}-azurelinux-${RELEASE_NUMBER}-1.$arch"
+		# rpm_pkg_dir="${pkg_name}-azurelinux-${RELEASE_NUMBER}-1.$arch"
 		azurelinux_build_required=1
 	fi
 

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -40,11 +40,7 @@ generate_rpm_package()
 
 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin.
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin
-	if [ "$rpm_dir" == "azurelinux" ]; then
-		gcc ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
-	else
-		gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
-	fi
+	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
 
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
@@ -262,4 +258,3 @@ if [ "$BUILD_MACHINE" != "azurelinux" ]; then
 else
 	generate_rpm_package azurelinux
 fi
-

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -67,19 +67,9 @@ generate_rpm_package()
 	# copy the aznfsclient config file.
 	cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
 
-	# Common handling for aznfsclient binary copy across all distros.
-	# Define the source and destination for aznfsclient.
-	aznfsclient_src="${SOURCE_DIR}/turbonfs/build/aznfsclient"
-	aznfsclient_target="${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient"
-
-	# Copy the built aznfsclient binary to the target
-	cp -avf "${aznfsclient_src}" "${aznfsclient_target}"
-
-	# Fail early if copy fails
-	if [ ! -f "${aznfsclient_target}" ]; then
-		echo "Error: aznfsclient failed to copy to ${aznfsclient_target}"
-		exit 1
-	fi
+	# aznfsclient in the final target dir.
+	aznfsclient=${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
+	cp -avf ${SOURCE_DIR}/turbonfs/build/aznfsclient ${aznfsclient}
 
 	if [ "$rpm_dir" != "azurelinux" ]; then
 		#
@@ -122,9 +112,9 @@ generate_rpm_package()
 		sed -i -e "s/PROCPS_PACKAGE_NAME/procps/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		sed -i -e "s/DISTRO/suse/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 	else
-		if [ "$rpm_dir" == "azurelinux" ]; then
-			sed -i -e "s/AZNFS_PACKAGE_NAME/${pkg_name}-azurelinux/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
-		fi
+		# if [ "$rpm_dir" == "azurelinux" ]; then
+		# 	sed -i -e "s/AZNFS_PACKAGE_NAME/${pkg_name}-azurelinux/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
+		# fi
 
 		sed -i -e "s/NETCAT_PACKAGE_NAME/nmap-ncat/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		# In Centos/RedHat/Rocky, procps-ng provides pgrep.
@@ -154,31 +144,31 @@ rpm_buildroot_dir="${rpmbuild_dir}/BUILDROOT"
 sed -i -e "s/RELEASE_NUMBER=x.y.z/RELEASE_NUMBER=${RELEASE_NUMBER}/g" ${SOURCE_DIR}/scripts/aznfs_install.sh
 
 
-if [ "$BUILD_MACHINE" != "azurelinux" ]; then
-	#########################
-	# Generate .deb package #
-	#########################
+# if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+# 	#########################
+# 	# Generate .deb package #
+# 	#########################
 
-	# Create the directory to hold the package control and data files for deb package.
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
+# 	# Create the directory to hold the package control and data files for deb package.
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
 
-	# Copy the debian control file(s) and maintainer scripts.
-	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
-	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
+# 	# Copy the debian control file(s) and maintainer scripts.
+# 	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
+# 	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
 
-	# Insert current release number.
-	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+# 	# Insert current release number.
+# 	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+# 	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
 
-	# Copy other static package file(s).
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
-	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+# 	# Copy other static package file(s).
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
+# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
 
-	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
-	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
-fi
+# 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
+# 	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+# fi
 
 
 #
@@ -222,6 +212,30 @@ make
 popd
 
 if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+	#########################
+	# Generate .deb package #
+	#########################
+
+	# Create the directory to hold the package control and data files for deb package.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
+
+	# Copy the debian control file(s) and maintainer scripts.
+	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
+	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
+
+	# Insert current release number.
+	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+
+	# Copy other static package file(s).
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+
+	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
+	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+
 	mkdir -p ${STG_DIR}/deb/${pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
 	cp -avf ${SOURCE_DIR}/src/mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -26,16 +26,9 @@ generate_rpm_package()
 	custom_stunnel_required=0
 	azurelinux_build_required=0
 
-	# Overwrite rpm_pkg_dir in case of RedHat7 and Centos7.
-	if [ "$rpm_dir" == "stunnel" ]; then
-		custom_stunnel_required=1
-	fi
-
-	# Overwrite rpm_pkg_dir in case of azurelinux.
-	if [ "$rpm_dir" == "azurelinux" ]; then
-		# rpm_pkg_dir="${pkg_name}-azurelinux-${RELEASE_NUMBER}-1.$arch"
-		azurelinux_build_required=1
-	fi
+    # Set flags based on rpm_dir type
+    [ "$rpm_dir" == "stunnel" ] && custom_stunnel_required=1
+    [ "$rpm_dir" == "azurelinux" ] && azurelinux_build_required=1
 
 	# Create the directory to hold the package spec and data files for RPM package.
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}
@@ -47,7 +40,11 @@ generate_rpm_package()
 
 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin.
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin
-	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	if [ "$rpm_dir" == "azurelinux" ]; then
+		gcc ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	else
+		gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	fi
 
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
@@ -112,9 +109,6 @@ generate_rpm_package()
 		sed -i -e "s/PROCPS_PACKAGE_NAME/procps/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		sed -i -e "s/DISTRO/suse/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 	else
-		# if [ "$rpm_dir" == "azurelinux" ]; then
-		# 	sed -i -e "s/AZNFS_PACKAGE_NAME/${pkg_name}-azurelinux/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
-		# fi
 
 		sed -i -e "s/NETCAT_PACKAGE_NAME/nmap-ncat/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		# In Centos/RedHat/Rocky, procps-ng provides pgrep.
@@ -142,39 +136,6 @@ rpm_buildroot_dir="${rpmbuild_dir}/BUILDROOT"
 
 # Insert release number to aznfs_install.sh
 sed -i -e "s/RELEASE_NUMBER=x.y.z/RELEASE_NUMBER=${RELEASE_NUMBER}/g" ${SOURCE_DIR}/scripts/aznfs_install.sh
-
-
-# if [ "$BUILD_MACHINE" != "azurelinux" ]; then
-# 	#########################
-# 	# Generate .deb package #
-# 	#########################
-
-# 	# Create the directory to hold the package control and data files for deb package.
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
-
-# 	# Copy the debian control file(s) and maintainer scripts.
-# 	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
-# 	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
-
-# 	# Insert current release number.
-# 	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-# 	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-
-# 	# Copy other static package file(s).
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
-# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-
-# 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
-# 	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
-# fi
-
-
-#
-# We build the turbonfs project here, note that we can set all cmake options in the 
-# future using env variables.
-#
 
 pushd ${SOURCE_DIR}/turbonfs
 export VCPKG_ROOT=${SOURCE_DIR}/turbonfs/extern/vcpkg

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -24,10 +24,17 @@ generate_rpm_package()
 {
 	rpm_dir=$1
 	custom_stunnel_required=0
+	azurelinux_build_required=0
 
 	# Overwrite rpm_pkg_dir in case of RedHat7 and Centos7.
 	if [ "$rpm_dir" == "stunnel" ]; then
 		custom_stunnel_required=1
+	fi
+
+	# Overwrite rpm_pkg_dir in case of azurelinux.
+	if [ "$rpm_dir" == "azurelinux" ]; then
+		rpm_pkg_dir="${pkg_name}-azurelinux-${RELEASE_NUMBER}-1.$arch"
+		azurelinux_build_required=1
 	fi
 
 	# Create the directory to hold the package spec and data files for RPM package.
@@ -60,17 +67,33 @@ generate_rpm_package()
 	# copy the aznfsclient config file.
 	cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
 
-	# copy the aznfsclient binary.
-	cp -avf ${aznfsclient} ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
+	if [ "$rpm_dir" != "azurelinux" ]; then
+		# copy the aznfsclient binary.
+		cp -avf ${aznfsclient} ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
+	else
+		# Define the final target location for aznfsclient
+		aznfsclient_target="${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient"
 
-	#
-	# Package aznfsclient dependencies in opt_dir/libs.
-	# libs_dir must already be populated with the required dependencies from
-	# the debian packaging step. Simply copy all those to rpm_libs_dir.
-	#
-	rpm_libs_dir=${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/libs
-	mkdir -p ${rpm_libs_dir}
-	cp -avfH ${libs_dir}/* ${rpm_libs_dir}
+		# Copy the built aznfsclient binary to the target
+		cp -avf "${SOURCE_DIR}/turbonfs/build/aznfsclient" "${aznfsclient_target}"
+
+		# Optional: fail early if copy fails
+		if [ ! -f "${aznfsclient_target}" ]; then
+			echo "Error: aznfsclient failed to copy to ${aznfsclient_target}"
+			exit 1
+		fi
+	fi
+
+	if [ "$rpm_dir" != "azurelinux" ]; then
+		#
+		# Package aznfsclient dependencies in opt_dir/libs.
+		# libs_dir must already be populated with the required dependencies from
+		# the debian packaging step. Simply copy all those to rpm_libs_dir.
+		#
+		rpm_libs_dir=${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/libs
+		mkdir -p ${rpm_libs_dir}
+		cp -avfH ${libs_dir}/* ${rpm_libs_dir}
+	fi
 
 	# Create the archive for the package.
 	tar -cvzf ${STG_DIR}/${rpm_pkg_dir}.tar.gz -C ${STG_DIR}/${rpm_dir}/tmp root
@@ -78,14 +101,16 @@ generate_rpm_package()
 	# Copy the SPEC file to change the placeholders depending upon the RPM distro.
 	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/RPM/aznfs.spec ${STG_DIR}/${rpm_dir}/tmp/
 
-	#
-	# Insert the contents of ${rpm_libs_dir}.
-	# This is variable due to the shared library versions.
-	# sed doesn't (easily) support replace target to be multi-line, so we use
-	# awk for this one.
-	#
-	opt_libs=$(for lib in ${rpm_libs_dir}/*; do echo ${opt_dir}/libs/$(basename $lib); done)
-	awk -i inplace -v r="$opt_libs" '{gsub(/OPT_LIBS/,r)}1' ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
+	if [ "$rpm_dir" != "azurelinux" ]; then
+		#
+		# Insert the contents of ${rpm_libs_dir}.
+		# This is variable due to the shared library versions.
+		# sed doesn't (easily) support replace target to be multi-line, so we use
+		# awk for this one.
+		#
+		opt_libs=$(for lib in ${rpm_libs_dir}/*; do echo ${opt_dir}/libs/$(basename $lib); done)
+		awk -i inplace -v r="$opt_libs" '{gsub(/OPT_LIBS/,r)}1' ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
+	fi
 
 	# Insert current release number and RPM_DIR value.
 	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
@@ -100,6 +125,10 @@ generate_rpm_package()
 		sed -i -e "s/PROCPS_PACKAGE_NAME/procps/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		sed -i -e "s/DISTRO/suse/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 	else
+		if [ "$rpm_dir" == "azurelinux" ]; then
+			sed -i -e "s/AZNFS_PACKAGE_NAME/${pkg_name}-azurelinux/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
+		fi
+
 		sed -i -e "s/NETCAT_PACKAGE_NAME/nmap-ncat/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 		# In Centos/RedHat/Rocky, procps-ng provides pgrep.
 		sed -i -e "s/PROCPS_PACKAGE_NAME/procps-ng/g" ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
@@ -108,7 +137,7 @@ generate_rpm_package()
 	fi
 
 	# Create the rpm package.
-	rpmbuild --define "custom_stunnel $custom_stunnel_required" --define "_topdir ${STG_DIR}/${rpm_dir}${rpmbuild_dir}" -v -bb ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
+	rpmbuild --define "custom_stunnel $custom_stunnel_required" --define "azurelinux_build $azurelinux_build_required" --define "_topdir ${STG_DIR}/${rpm_dir}${rpmbuild_dir}" -v -bb ${STG_DIR}/${rpm_dir}/tmp/aznfs.spec
 
 	# Remove the temporary files.
 	rm ${STG_DIR}/${rpm_pkg_dir}.tar.gz
@@ -127,29 +156,33 @@ rpm_buildroot_dir="${rpmbuild_dir}/BUILDROOT"
 # Insert release number to aznfs_install.sh
 sed -i -e "s/RELEASE_NUMBER=x.y.z/RELEASE_NUMBER=${RELEASE_NUMBER}/g" ${SOURCE_DIR}/scripts/aznfs_install.sh
 
-#########################
-# Generate .deb package #
-#########################
 
-# Create the directory to hold the package control and data files for deb package.
-mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
+if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+	#########################
+	# Generate .deb package #
+	#########################
 
-# Copy the debian control file(s) and maintainer scripts.
-cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
-chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
+	# Create the directory to hold the package control and data files for deb package.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
 
-# Insert current release number.
-sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+	# Copy the debian control file(s) and maintainer scripts.
+	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
+	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
 
-# Copy other static package file(s).
-mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
-cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+	# Insert current release number.
+	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
 
-# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
-mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
-gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+	# Copy other static package file(s).
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+
+	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
+	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+fi
+
 
 #
 # We build the turbonfs project here, note that we can set all cmake options in the 
@@ -170,6 +203,13 @@ else
     INSECURE_AUTH_FOR_DEVTEST=OFF
 fi
 
+# Run azurelinux packaging only on azurelinux runner
+if [ "$BUILD_MACHINE" == "azurelinux" ]; then
+    DYNAMIC_LINKS=ON
+else
+	DYNAMIC_LINKS=OFF
+fi
+
 # vcpkg required env variable VCPKG_FORCE_SYSTEM_BINARIES to be set for arm64.
 if [ "$(uname -m)" == "aarch64" ]; then
     export VCPKG_FORCE_SYSTEM_BINARIES=1
@@ -178,68 +218,73 @@ fi
 cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DENABLE_PARANOID=${PARANOID} \
       -DENABLE_INSECURE_AUTH_FOR_DEVTEST=${INSECURE_AUTH_FOR_DEVTEST} \
+	  -DENABLE_DYNAMIC_LINKS=${DYNAMIC_LINKS} \
       -DPACKAGE_VERSION="${RELEASE_NUMBER}" \
       -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..
 make
 popd
 
-mkdir -p ${STG_DIR}/deb/${pkg_dir}${opt_dir}
-cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
-cp -avf ${SOURCE_DIR}/src/mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
-cp -avf ${SOURCE_DIR}/src/nfsv3mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
-cp -avf ${SOURCE_DIR}/src/nfsv4mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
-cp -avf ${SOURCE_DIR}/scripts/aznfs_install.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
-cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/deb/${pkg_dir}/${opt_dir}/
+if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}${opt_dir}
+	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
+	cp -avf ${SOURCE_DIR}/src/mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
+	cp -avf ${SOURCE_DIR}/src/nfsv3mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
+	cp -avf ${SOURCE_DIR}/src/nfsv4mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
+	cp -avf ${SOURCE_DIR}/scripts/aznfs_install.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
+	cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/deb/${pkg_dir}/${opt_dir}/
 
-mkdir -p ${STG_DIR}/deb/${pkg_dir}${system_dir}
-cp -avf ${SOURCE_DIR}/src/aznfswatchdog.service ${STG_DIR}/deb/${pkg_dir}${system_dir}
-cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4.service ${STG_DIR}/deb/${pkg_dir}${system_dir}
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}${system_dir}
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdog.service ${STG_DIR}/deb/${pkg_dir}${system_dir}
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4.service ${STG_DIR}/deb/${pkg_dir}${system_dir}
 
-###########################################
-# Bundle aznfsclient and its dependencies #
-###########################################
+	###########################################
+	# Bundle aznfsclient and its dependencies #
+	###########################################
 
-# aznfsclient in the final target dir.
-aznfsclient=${STG_DIR}/deb/${pkg_dir}/sbin/aznfsclient
-cp -avf ${SOURCE_DIR}/turbonfs/build/aznfsclient ${aznfsclient}
+	# aznfsclient in the final target dir.
+	aznfsclient=${STG_DIR}/deb/${pkg_dir}/sbin/aznfsclient
+	cp -avf ${SOURCE_DIR}/turbonfs/build/aznfsclient ${aznfsclient}
 
-# Package aznfsclient dependencies in opt_dir.
-libs_dir=${STG_DIR}/deb/${pkg_dir}${opt_dir}/libs
-mkdir -p ${libs_dir}
+	# Package aznfsclient dependencies in opt_dir.
+	libs_dir=${STG_DIR}/deb/${pkg_dir}${opt_dir}/libs
+	mkdir -p ${libs_dir}
 
-# Copy the dependencies.
-cp -avfH $(ldd ${aznfsclient} | grep "=>" | awk '{print $3}') ${libs_dir}
+	# Copy the dependencies.
+	cp -avfH $(ldd ${aznfsclient} | grep "=>" | awk '{print $3}') ${libs_dir}
 
-#
-# Patch all the libs to reference shared libs from ${libs_dir}.
-# This is our very simple containerization.
-#
-for lib in ${libs_dir}/*.so*; do
-	echo "Setting rpath to ${opt_dir}/libs for $lib"
-	patchelf --set-rpath ${opt_dir}/libs "$lib"
-done
+	#
+	# Patch all the libs to reference shared libs from ${libs_dir}.
+	# This is our very simple containerization.
+	#
+	for lib in ${libs_dir}/*.so*; do
+		echo "Setting rpath to ${opt_dir}/libs for $lib"
+		patchelf --set-rpath ${opt_dir}/libs "$lib"
+	done
 
-#
-# Final containerization effort - bundle and use the same interpreter as the
-# build machine.
-#
-ld_linux_path=$(ldd ${aznfsclient} | grep "ld-linux" | awk '{print $1}')
-ld_linux_name=$(basename "$ld_linux_path")
-ld_linux="${libs_dir}/${ld_linux_name}"
-cp -avfH  "${ld_linux_path}" "${ld_linux}"
+	#
+	# Final containerization effort - bundle and use the same interpreter as the
+	# build machine.
+	#
+	ld_linux_path=$(ldd ${aznfsclient} | grep "ld-linux" | awk '{print $1}')
+	ld_linux_name=$(basename "$ld_linux_path")
+	ld_linux="${libs_dir}/${ld_linux_name}"
+	cp -avfH  "${ld_linux_path}" "${ld_linux}"
 
-patchelf --set-interpreter ${opt_dir}/libs/${ld_linux_name} ${aznfsclient}
+	patchelf --set-interpreter ${opt_dir}/libs/${ld_linux_name} ${aznfsclient}
 
-# Create the deb package.
-dpkg-deb -Zgzip --root-owner-group --build $STG_DIR/deb/$pkg_dir
+	# Create the deb package.
+	dpkg-deb -Zgzip --root-owner-group --build $STG_DIR/deb/$pkg_dir
 
-#########################
-# Generate .rpm package #
-#########################
+	#########################
+	# Generate .rpm package #
+	#########################
 
-generate_rpm_package rpm
-generate_rpm_package suse
-# Generate rpm package with custom stunnel installation for RedHat7 and Centos7.
-generate_rpm_package stunnel
+	generate_rpm_package rpm
+	generate_rpm_package suse
+	# Generate rpm package with custom stunnel installation for RedHat7 and Centos7.
+	generate_rpm_package stunnel
+else
+	generate_rpm_package azurelinux
+fi
 
 

--- a/generate_package.sh
+++ b/generate_package.sh
@@ -64,9 +64,11 @@ generate_rpm_package()
 	# copy the aznfsclient config file.
 	cp -avf ${SOURCE_DIR}/turbonfs/sample-turbo-config.yaml ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
 
-	# aznfsclient in the final target dir.
-	aznfsclient=${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
-	cp -avf ${SOURCE_DIR}/turbonfs/build/aznfsclient ${aznfsclient}
+	if [ "$rpm_dir" != "azurelinux" ]; then
+		cp -avf ${aznfsclient} ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
+	else
+		cp -avf ${SOURCE_DIR}/turbonfs/build/aznfsclient ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/aznfsclient
+	fi
 
 	if [ "$rpm_dir" != "azurelinux" ]; then
 		#
@@ -258,5 +260,4 @@ if [ "$BUILD_MACHINE" != "azurelinux" ]; then
 else
 	generate_rpm_package azurelinux
 fi
-
 

--- a/package.sh
+++ b/package.sh
@@ -294,6 +294,27 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DPACKAGE_VERSION="${RELEASE_NUMBER}" \
       -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..
 make
+
+# ****** TODO: REMOVE LATER **************
+# Verify the built binary immediately after make
+echo "===== POST-BUILD VERIFICATION ====="
+BUILT_BINARY="${SOURCE_DIR}/turbonfs/build/aznfsclient"
+echo "Checking: ${BUILT_BINARY}"
+ls -lh "${BUILT_BINARY}"
+file "${BUILT_BINARY}"
+echo "LDD output:"
+ldd "${BUILT_BINARY}" | grep -E "fuse3|libfuse|libasan"
+
+if [ "$BUILD_MACHINE" == "azurelinux" ]; then
+    if ldd "${BUILT_BINARY}" | grep -q "libfuse3.so"; then
+        echo "✓ fuse3 dynamically linked"
+    else
+        echo "✗ ERROR: fuse3 NOT dynamically linked!"
+        exit 1
+    fi
+fi
+echo "====================================="
+
 popd
 
 if [ "$BUILD_MACHINE" != "azurelinux" ]; then

--- a/package.sh
+++ b/package.sh
@@ -303,14 +303,13 @@ echo "Checking: ${BUILT_BINARY}"
 ls -lh "${BUILT_BINARY}"
 file "${BUILT_BINARY}"
 echo "LDD output:"
-ldd "${BUILT_BINARY}" | grep -E "fuse3|libfuse|libasan"
+ldd "${BUILT_BINARY}"
 
 if [ "$BUILD_MACHINE" == "azurelinux" ]; then
     if ldd "${BUILT_BINARY}" | grep -q "libfuse3.so"; then
         echo "✓ fuse3 dynamically linked"
     else
         echo "✗ ERROR: fuse3 NOT dynamically linked!"
-        exit 1
     fi
 fi
 echo "====================================="

--- a/package.sh
+++ b/package.sh
@@ -53,7 +53,11 @@ generate_rpm_package()
 
 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin.
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin
-	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	if [ "$rpm_dir" == "azurelinux" ]; then
+		gcc ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	else
+		gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
+	fi
 
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/
@@ -223,32 +227,6 @@ rpm_buildroot_dir="${rpmbuild_dir}/BUILDROOT"
 
 # Insert release number to aznfs_install.sh
 sed -i -e "s/RELEASE_NUMBER=x.y.z/RELEASE_NUMBER=${RELEASE_NUMBER}/g" ${SOURCE_DIR}/scripts/aznfs_install.sh
-
-# if [ "$BUILD_MACHINE" != "azurelinux" ]; then
-# 	#########################
-# 	# Generate .deb package #
-# 	#########################
-
-# 	# Create the directory to hold the package control and data files for deb package.
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
-
-# 	# Copy the debian control file(s) and maintainer scripts.
-# 	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
-# 	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
-
-# 	# Insert current release number.
-# 	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-# 	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-
-# 	# Copy other static package file(s).
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
-# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-
-# 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
-# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
-# 	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
-# fi
 
 #
 # We build the turbonfs project here, note that we can set all cmake options in the 

--- a/package.sh
+++ b/package.sh
@@ -82,12 +82,6 @@ generate_rpm_package()
 
 		# Copy the built aznfsclient binary to the target
 		cp -avf "${SOURCE_DIR}/turbonfs/build/aznfsclient" "${aznfsclient_target}"
-
-		# Optional: fail early if copy fails
-		if [ ! -f "${aznfsclient_target}" ]; then
-			echo "Error: aznfsclient failed to copy to ${aznfsclient_target}"
-			exit 1
-		fi
 	fi
 
 	if [ "$rpm_dir" != "azurelinux" ]; then
@@ -230,31 +224,31 @@ rpm_buildroot_dir="${rpmbuild_dir}/BUILDROOT"
 # Insert release number to aznfs_install.sh
 sed -i -e "s/RELEASE_NUMBER=x.y.z/RELEASE_NUMBER=${RELEASE_NUMBER}/g" ${SOURCE_DIR}/scripts/aznfs_install.sh
 
-if [ "$BUILD_MACHINE" != "azurelinux" ]; then
-	#########################
-	# Generate .deb package #
-	#########################
+# if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+# 	#########################
+# 	# Generate .deb package #
+# 	#########################
 
-	# Create the directory to hold the package control and data files for deb package.
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
+# 	# Create the directory to hold the package control and data files for deb package.
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
 
-	# Copy the debian control file(s) and maintainer scripts.
-	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
-	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
+# 	# Copy the debian control file(s) and maintainer scripts.
+# 	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
+# 	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
 
-	# Insert current release number.
-	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
-	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+# 	# Insert current release number.
+# 	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+# 	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
 
-	# Copy other static package file(s).
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
-	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
-	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+# 	# Copy other static package file(s).
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
+# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+# 	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
 
-	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
-	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
-	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
-fi
+# 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
+# 	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
+# 	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+# fi
 
 #
 # We build the turbonfs project here, note that we can set all cmake options in the 
@@ -297,6 +291,30 @@ make
 popd
 
 if [ "$BUILD_MACHINE" != "azurelinux" ]; then
+	#########################
+	# Generate .deb package #
+	#########################
+
+	# Create the directory to hold the package control and data files for deb package.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/DEBIAN
+
+	# Copy the debian control file(s) and maintainer scripts.
+	cp -avf ${SOURCE_DIR}/packaging/${pkg_name}/DEBIAN/* ${STG_DIR}/deb/${pkg_dir}/DEBIAN/
+	chmod +x ${STG_DIR}/deb/${pkg_dir}/DEBIAN/*
+
+	# Insert current release number.
+	sed -i -e "s/Version: x.y.z/Version: ${RELEASE_NUMBER}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+	sed -i -e "s/BUILD_ARCH/${debarch}/g" ${STG_DIR}/deb/${pkg_dir}/DEBIAN/control
+
+	# Copy other static package file(s).
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/usr/sbin
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdog ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+	cp -avf ${SOURCE_DIR}/src/aznfswatchdogv4 ${STG_DIR}/deb/${pkg_dir}/usr/sbin/
+
+	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/deb/${pkg_dir}/sbin.
+	mkdir -p ${STG_DIR}/deb/${pkg_dir}/sbin
+	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/deb/${pkg_dir}/sbin/mount.aznfs
+
 	mkdir -p ${STG_DIR}/deb/${pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/
 	cp -avf ${SOURCE_DIR}/src/mountscript.sh ${STG_DIR}/deb/${pkg_dir}${opt_dir}/

--- a/package.sh
+++ b/package.sh
@@ -294,26 +294,6 @@ cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -DPACKAGE_VERSION="${RELEASE_NUMBER}" \
       -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..
 make
-
-# ****** TODO: REMOVE LATER **************
-# Verify the built binary immediately after make
-echo "===== POST-BUILD VERIFICATION ====="
-BUILT_BINARY="${SOURCE_DIR}/turbonfs/build/aznfsclient"
-echo "Checking: ${BUILT_BINARY}"
-ls -lh "${BUILT_BINARY}"
-file "${BUILT_BINARY}"
-echo "LDD output:"
-ldd "${BUILT_BINARY}"
-
-if [ "$BUILD_MACHINE" == "azurelinux" ]; then
-    if ldd "${BUILT_BINARY}" | grep -q "libfuse3.so"; then
-        echo "✓ fuse3 dynamically linked"
-    else
-        echo "✗ ERROR: fuse3 NOT dynamically linked!"
-    fi
-fi
-echo "====================================="
-
 popd
 
 if [ "$BUILD_MACHINE" != "azurelinux" ]; then

--- a/package.sh
+++ b/package.sh
@@ -53,11 +53,7 @@ generate_rpm_package()
 
 	# Compile mount.aznfs.c and put the executable into ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin.
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin
-	if [ "$rpm_dir" == "azurelinux" ]; then
-		gcc ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
-	else
-		gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
-	fi
+	gcc -static ${SOURCE_DIR}/src/mount.aznfs.c -o ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}/sbin/mount.aznfs
 
 	mkdir -p ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}
 	cp -avf ${SOURCE_DIR}/lib/common.sh ${STG_DIR}/${rpm_dir}/tmp${rpm_buildroot_dir}/${rpm_pkg_dir}${opt_dir}/

--- a/packaging/aznfs/RPM/aznfs.spec
+++ b/packaging/aznfs/RPM/aznfs.spec
@@ -9,7 +9,7 @@ Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, ipro
 Recommends: build-essential
 
 %elif 0%{?azurelinux_build}
-Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools, gnutls, jemalloc, libasan
+Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools, gnutls, jemalloc, libasan, fuse3
 
 %else
 Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools

--- a/packaging/aznfs/RPM/aznfs.spec
+++ b/packaging/aznfs/RPM/aznfs.spec
@@ -7,6 +7,10 @@ URL: https://github.com/Azure/AZNFS-mount/blob/main/README.md
 %if 0%{?custom_stunnel}
 Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, net-tools, binutils, kernel-headers, openssl, openssl-devel, gcc, make, wget
 Recommends: build-essential
+
+%elif 0%{?azurelinux_build}
+Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools, gnutls, jemalloc, libasan
+
 %else
 Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, iproute, util-linux, nfs-utils, NETCAT_PACKAGE_NAME, newt, stunnel, net-tools
 %endif
@@ -41,7 +45,9 @@ tar -xzvf ${STG_DIR}/AZNFS_PACKAGE_NAME-${RELEASE_NUMBER}-1.BUILD_ARCH.tar.gz -C
 /opt/microsoft/aznfs/aznfs_install.sh
 /lib/systemd/system/aznfswatchdog.service
 /lib/systemd/system/aznfswatchdogv4.service
+%if !0%{?azurelinux_build}
 OPT_LIBS
+%endif
 /opt/microsoft/aznfs/sample-turbo-config.yaml
 /sbin/aznfsclient
 

--- a/packaging/aznfs/RPM/aznfs.spec
+++ b/packaging/aznfs/RPM/aznfs.spec
@@ -24,8 +24,10 @@ Requires: bash, PROCPS_PACKAGE_NAME, conntrack-tools, iptables, bind-utils, ipro
 # and not confuse other packages with those. Since we are self sufficient and we don't need any libs from the system,
 # we use the __requires_exclude_from directive to tell the package manager.
 #
+%if !0%{?azurelinux_build}
 %global __provides_exclude_from ^/opt/microsoft/aznfs/libs/.*\.so.*$
 %global __requires_exclude_from ^(/opt/microsoft/aznfs/libs/.*\.so.*|/sbin/aznfsclient)$
+%endif
 
 %description
 Mount helper program for Azure Blob NFS mounts, providing a secure communication channel for Azure File NFS mounts, and supporting the Turbo NFS client

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -212,12 +212,6 @@ if(ENABLE_DYNAMIC_LINKS)
     message(STATUS "Found fuse3 libraries: ${FUSE3_LIBRARIES}")
     message(STATUS "Found fuse3 include dirs: ${FUSE3_INCLUDE_DIRS}")
     message(STATUS "Found fuse3 library dirs: ${FUSE3_LIBRARY_DIRS}")
-
-    target_include_directories(${CMAKE_PROJECT_NAME}
-        PRIVATE ${FUSE3_INCLUDE_DIRS}
-    )
-
-    target_link_libraries(${CMAKE_PROJECT_NAME} ${FUSE3_LIBRARIES})
 else()
     #
     # For static builds, build libfuse from source

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -567,3 +567,15 @@ endforeach()
 message(STATUS "===============================================")
 
 install(TARGETS ${CMAKE_PROJECT_NAME})
+
+# *********** TODO: REMOVE LATER. *********
+# Add post-build verification for dynamic builds
+if(ENABLE_DYNAMIC_LINKS AND NOT ENABLE_NO_FUSE)
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "===== Verifying dynamic fuse3 linking ====="
+        COMMAND ldd $<TARGET_FILE:${CMAKE_PROJECT_NAME}> | grep -E "(fuse3|libfuse)" || 
+                (echo "ERROR: fuse3 NOT found in ldd output!" && exit 1)
+        COMMAND ${CMAKE_COMMAND} -E echo "===== fuse3 successfully linked ====="
+        COMMENT "Verifying fuse3 dynamic linking"
+    )
+endif()

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -184,24 +184,40 @@ if(ENABLE_DYNAMIC_LINKS)
     # For dynamic builds, use system-installed fuse3 shared library
     #
     message(STATUS "Using system-installed fuse3 (dynamic linking)")
-    pkg_search_module(FUSE3 REQUIRED fuse3-devel)
-    
+
+    # First try to find fuse3 via pkg-config
+    find_package(PkgConfig REQUIRED)
+    pkg_search_module(FUSE3 QUIET fuse3)
+
     if(NOT FUSE3_FOUND)
-        message(FATAL_ERROR "fuse3 not found! Please install fuse3-devel package: sudo tdnf install -y fuse3-devel")
+        message(STATUS "fuse3 not found via pkg-config, trying to install the devel package")
+
+        if(PKG_MGR STREQUAL "apt")
+            set(FUSE3_PKG "libfuse3-dev")
+        else()
+            set(FUSE3_PKG "fuse3-devel")
+        endif()
+
+        execute_process(COMMAND sudo ${PKG_MGR} install -y ${FUSE3_PKG}
+                        RESULT_VARIABLE FUSE3_INSTALL_RESULT)
+
+        if(NOT FUSE3_INSTALL_RESULT EQUAL "0")
+            message(FATAL_ERROR "Failed to install ${FUSE3_PKG}, please install manually")
+        endif()
+
+        # Retry finding fuse3 after installation
+        pkg_search_module(FUSE3 REQUIRED fuse3)
     endif()
-    
+
     message(STATUS "Found fuse3 libraries: ${FUSE3_LIBRARIES}")
     message(STATUS "Found fuse3 include dirs: ${FUSE3_INCLUDE_DIRS}")
     message(STATUS "Found fuse3 library dirs: ${FUSE3_LIBRARY_DIRS}")
 
     target_include_directories(${CMAKE_PROJECT_NAME}
-        PRIVATE
-        ${FUSE3_INCLUDE_DIRS}
+        PRIVATE ${FUSE3_INCLUDE_DIRS}
     )
 
-    target_link_libraries(${CMAKE_PROJECT_NAME}
-        ${FUSE3_LIBRARIES}
-    )
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${FUSE3_LIBRARIES})
 else()
     #
     # For static builds, build libfuse from source

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -567,15 +567,3 @@ endforeach()
 message(STATUS "===============================================")
 
 install(TARGETS ${CMAKE_PROJECT_NAME})
-
-# *********** TODO: REMOVE LATER. *********
-# Add post-build verification for dynamic builds
-if(ENABLE_DYNAMIC_LINKS AND NOT ENABLE_NO_FUSE)
-    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E echo "===== Verifying dynamic fuse3 linking ====="
-        COMMAND ldd $<TARGET_FILE:${CMAKE_PROJECT_NAME}> | grep -E "(fuse3|libfuse)" || 
-                (echo "ERROR: fuse3 NOT found in ldd output!" && exit 1)
-        COMMAND ${CMAKE_COMMAND} -E echo "===== fuse3 successfully linked ====="
-        COMMENT "Verifying fuse3 dynamic linking"
-    )
-endif()

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -27,7 +27,6 @@ option(ENABLE_JEMALLOC "Use jemalloc for malloc/free/new/delete" ON)
 option(ENABLE_INSECURE_AUTH_FOR_DEVTEST "Enable AZAUTH for non-TLS connections" OFF)
 option(ENABLE_DYNAMIC_LINKS "Use dynamic linking instead of bundling libs" OFF)
 
-message(STATUS "ENABLE_INSECURE_AUTH_FOR_DEVTEST = ${ENABLE_INSECURE_AUTH_FOR_DEVTEST}")
 #
 # Builds that make it to customers need to be extra careful about any unnecessary
 # logging. Some warning logs we have in our code are to attract developer
@@ -87,8 +86,11 @@ endif()
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for binaries")
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 
-set(LIBFUSE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/libfuse")
-set(LIBFUSE_BUILD_DIR "${CMAKE_BINARY_DIR}/extern/libfuse")
+# Only set libfuse paths for static builds
+if(NOT ENABLE_DYNAMIC_LINKS)
+    set(LIBFUSE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/libfuse")
+    set(LIBFUSE_BUILD_DIR "${CMAKE_BINARY_DIR}/extern/libfuse")
+endif()
 
 #
 # We add the following submodule(s), update them as needed, before starting.
@@ -125,8 +127,11 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/spdlog/CMakeLists.txt")
     message(FATAL_ERROR "The spdlog submodule was not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
 endif()
 
-if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/libfuse/meson.build")
-    message(FATAL_ERROR "The libfuse submodule was not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
+# Only check libfuse submodule for static builds
+if(NOT ENABLE_DYNAMIC_LINKS)
+    if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/libfuse/meson.build")
+        message(FATAL_ERROR "The libfuse submodule was not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")
+    endif()
 endif()
 
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extern/vcpkg/bootstrap-vcpkg.sh")
@@ -172,59 +177,71 @@ if(NOT PKG_CONFIG_FOUND)
 endif()
 
 #
-# We need meson to compile libfuse.
+# Handle FUSE3 based on build type
 #
-find_program(MESON_EXECUTABLE meson QUIET)
-if(NOT MESON_FOUND)
-    message(STATUS "meson not found, trying to install meson!")
-    execute_process(COMMAND sudo ${PKG_MGR} install -y meson
-                    RESULT_VARIABLE MESON_INSTALL_RESULT)
-    if(NOT MESON_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "${PKG_MGR} install meson failed with ${MESON_INSTALL_RESULT}, try installing meson manually and then run cmake again")
-    else()
-        find_program(MESON_EXECUTABLE meson REQUIRED)
-    endif()
-endif()
-
-#
-# We need ninja to install libfuse in build dir.
-#
-find_program(NINJA_EXECUTABLE ninja QUIET)
-if(NOT NINJA_FOUND)
-    message(STATUS "ninja not found, trying to install ninja-build!")
-    execute_process(COMMAND sudo ${PKG_MGR} install -y ninja-build
-                    RESULT_VARIABLE NINJA_INSTALL_RESULT)
-    if(NOT NINJA_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "${PKG_MGR} install ninja-build failed with ${NINJA_INSTALL_RESULT}, try installing ninja-build manually and then run cmake again")
-    else()
-        find_program(NINJA_EXECUTABLE ninja REQUIRED)
-    endif()
-endif()
-
-# Decide fuse3 paths based on ENABLE_DYNAMIC_LINKS.
 if(ENABLE_DYNAMIC_LINKS)
-    # Dynamic: Meson installs directly to /usr/local/lib.
-    set(fuse3_LIBRARY "/usr/local/lib/libfuse3.a")
+    #
+    # For dynamic builds, use system-installed fuse3 shared library
+    #
+    message(STATUS "Using system-installed fuse3 (dynamic linking)")
+    pkg_search_module(FUSE3 REQUIRED fuse3)
+    
+    if(NOT FUSE3_FOUND)
+        message(FATAL_ERROR "fuse3 not found! Please install fuse3-devel package: sudo tdnf install -y fuse3-devel")
+    endif()
+    
+    message(STATUS "Found fuse3 libraries: ${FUSE3_LIBRARIES}")
+    message(STATUS "Found fuse3 include dirs: ${FUSE3_INCLUDE_DIRS}")
+    message(STATUS "Found fuse3 library dirs: ${FUSE3_LIBRARY_DIRS}")
 else()
-    # Static: Use multiarch layout.
+    #
+    # For static builds, build libfuse from source
+    #
+    message(STATUS "Building libfuse from source (static linking)")
+    
+    #
+    # We need meson to compile libfuse.
+    #
+    find_program(MESON_EXECUTABLE meson QUIET)
+    if(NOT MESON_FOUND)
+        message(STATUS "meson not found, trying to install meson!")
+        execute_process(COMMAND sudo ${PKG_MGR} install -y meson
+                        RESULT_VARIABLE MESON_INSTALL_RESULT)
+        if(NOT MESON_INSTALL_RESULT EQUAL "0")
+            message(FATAL_ERROR "${PKG_MGR} install meson failed with ${MESON_INSTALL_RESULT}, try installing meson manually and then run cmake again")
+        else()
+            find_program(MESON_EXECUTABLE meson REQUIRED)
+        endif()
+    endif()
+
+    #
+    # We need ninja to install libfuse in build dir.
+    #
+    find_program(NINJA_EXECUTABLE ninja QUIET)
+    if(NOT NINJA_FOUND)
+        message(STATUS "ninja not found, trying to install ninja-build!")
+        execute_process(COMMAND sudo ${PKG_MGR} install -y ninja-build
+                        RESULT_VARIABLE NINJA_INSTALL_RESULT)
+        if(NOT NINJA_INSTALL_RESULT EQUAL "0")
+            message(FATAL_ERROR "${PKG_MGR} install ninja-build failed with ${NINJA_INSTALL_RESULT}, try installing ninja-build manually and then run cmake again")
+        else()
+            find_program(NINJA_EXECUTABLE ninja REQUIRED)
+        endif()
+    endif()
+
+    # Use multiarch layout for static builds
     set(fuse3_LIBRARY "/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/libfuse3.a")
+    set(fuse3_INCLUDE_DIR "/usr/local/include")
+
+    add_custom_command(
+        OUTPUT ${fuse3_LIBRARY}
+        COMMAND ${MESON_EXECUTABLE} setup ${LIBFUSE_BUILD_DIR} ${LIBFUSE_SOURCE_DIR} --default-library=static --buildtype=${MESON_BUILD_TYPE}
+        COMMAND ${MESON_EXECUTABLE} compile -C ${LIBFUSE_BUILD_DIR}
+        COMMAND sudo ${MESON_EXECUTABLE} install -C ${LIBFUSE_BUILD_DIR}
+    )
+
+    add_custom_target(libfuse ALL DEPENDS ${fuse3_LIBRARY})
 endif()
-
-# Include path remains the same for both cases.
-set(fuse3_INCLUDE_DIR "/usr/local/include")
-
-# Meson will install the fuse library and header files in the following paths.
-# set(fuse3_LIBRARY "/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/libfuse3.a")
-# set(fuse3_INCLUDE_DIR "/usr/local/include")
-
-add_custom_command(
-    OUTPUT ${fuse3_LIBRARY}
-    COMMAND ${MESON_EXECUTABLE} setup ${LIBFUSE_BUILD_DIR} ${LIBFUSE_SOURCE_DIR} --default-library=static --buildtype=${MESON_BUILD_TYPE}
-    COMMAND ${MESON_EXECUTABLE} compile -C ${LIBFUSE_BUILD_DIR}
-    COMMAND sudo ${MESON_EXECUTABLE} install -C ${LIBFUSE_BUILD_DIR}
-)
-
-add_custom_target(libfuse ALL DEPENDS ${fuse3_LIBRARY})
 
 #
 # We need GnuTLS for secure libnfs transport.
@@ -401,7 +418,10 @@ else()
 set(sources ${sources} src/main.cpp)
 add_executable(${CMAKE_PROJECT_NAME}
                ${sources})
-add_dependencies(${CMAKE_PROJECT_NAME} libfuse)
+    # Only add libfuse dependency for static builds
+    if(NOT ENABLE_DYNAMIC_LINKS)
+        add_dependencies(${CMAKE_PROJECT_NAME} libfuse)
+    endif()
 endif()
 
 # All include directories.
@@ -416,10 +436,15 @@ target_include_directories(${CMAKE_PROJECT_NAME}
                            PRIVATE "${PROJECT_SOURCE_DIR}/extern/spdlog/include")
 
 if(NOT ENABLE_NO_FUSE)
-target_include_directories(${CMAKE_PROJECT_NAME}
-                           PRIVATE "${fuse3_INCLUDE_DIR}")
-target_link_libraries(${CMAKE_PROJECT_NAME}
-                      ${fuse3_LIBRARY})
+    if(ENABLE_DYNAMIC_LINKS)
+        # Use system fuse3 include directories
+        target_include_directories(${CMAKE_PROJECT_NAME}
+                                   PRIVATE ${FUSE3_INCLUDE_DIRS})
+    else()
+        # Use built-from-source fuse3 include directory
+        target_include_directories(${CMAKE_PROJECT_NAME}
+                                   PRIVATE "${fuse3_INCLUDE_DIR}")
+    endif()
 endif()
 
 target_compile_options(${CMAKE_PROJECT_NAME}
@@ -490,6 +515,11 @@ if(ENABLE_DYNAMIC_LINKS)
                         nlohmann_json::nlohmann_json
                         uuid
                         GnuTLS::GnuTLS)
+  
+  # Link against system fuse3 (only if not building nofuse)
+  if(NOT ENABLE_NO_FUSE)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${FUSE3_LIBRARIES})
+  endif()
 else()
   # Static linking: Use static-libgcc/libstdc++ and explicit gnutls libraries
   target_link_libraries(${CMAKE_PROJECT_NAME}
@@ -506,6 +536,11 @@ else()
                         Azure::azure-storage-blobs
                         nlohmann_json::nlohmann_json
                         uuid)
+  
+  # Link against static fuse3 (only if not building nofuse)
+  if(NOT ENABLE_NO_FUSE)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${fuse3_LIBRARY})
+  endif()
 endif()
 
 if(ENABLE_TCMALLOC)

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -25,6 +25,9 @@ option(ENABLE_CHATTY "Enable super verbose logs" OFF)
 option(ENABLE_TCMALLOC "Use tcmalloc for malloc/free/new/delete" OFF)
 option(ENABLE_JEMALLOC "Use jemalloc for malloc/free/new/delete" ON)
 option(ENABLE_INSECURE_AUTH_FOR_DEVTEST "Enable AZAUTH for non-TLS connections" OFF)
+option(ENABLE_DYNAMIC_LINKS "Use dynamic linking instead of bundling libs" OFF)
+
+message(STATUS "ENABLE_INSECURE_AUTH_FOR_DEVTEST = ${ENABLE_INSECURE_AUTH_FOR_DEVTEST}")
 #
 # Builds that make it to customers need to be extra careful about any unnecessary
 # logging. Some warning logs we have in our code are to attract developer
@@ -144,16 +147,23 @@ if(NOT azure-storage-blobs-cpp_FOUND)
     message(FATAL_ERROR "azure-storage-blobs-cpp not found! Did you run cmake with -DCMAKE_TOOLCHAIN_FILE?")
 endif()
 
+# Choose package manager based on ENABLE_DYNAMIC_LINKS
+if(ENABLE_DYNAMIC_LINKS)
+    set(PKG_MGR tdnf)
+else()
+    set(PKG_MGR apt)
+endif()
+
 #
 # Ensure pkg_search_module(), needed for configuring some packages.
 #
 find_package(PkgConfig QUIET)
 if(NOT PKG_CONFIG_FOUND)
     message(STATUS "pkg-config not found, trying to install pkg-config!")
-    execute_process(COMMAND sudo apt install -y pkg-config
+    execute_process(COMMAND sudo ${PKG_MGR} install -y pkg-config
             RESULT_VARIABLE PKGCONFIG_INSTALL_RESULT)
     if(NOT PKGCONFIG_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install pkg-config failed with ${PKGCONFIG_INSTALL_RESULT}, try installing pkg-config manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install pkg-config failed with ${PKGCONFIG_INSTALL_RESULT}, try installing pkg-config manually and then run cmake again")
     else()
         # Call once more to ensure above install completed fine and also
         # add the pkg_search_module() command.
@@ -167,10 +177,10 @@ endif()
 find_program(MESON_EXECUTABLE meson QUIET)
 if(NOT MESON_FOUND)
     message(STATUS "meson not found, trying to install meson!")
-    execute_process(COMMAND sudo apt install -y meson
+    execute_process(COMMAND sudo ${PKG_MGR} install -y meson
                     RESULT_VARIABLE MESON_INSTALL_RESULT)
     if(NOT MESON_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install meson failed with ${MESON_INSTALL_RESULT}, try installing meson manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install meson failed with ${MESON_INSTALL_RESULT}, try installing meson manually and then run cmake again")
     else()
         find_program(MESON_EXECUTABLE meson REQUIRED)
     endif()
@@ -182,18 +192,30 @@ endif()
 find_program(NINJA_EXECUTABLE ninja QUIET)
 if(NOT NINJA_FOUND)
     message(STATUS "ninja not found, trying to install ninja-build!")
-    execute_process(COMMAND sudo apt install -y ninja-build
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ninja-build
                     RESULT_VARIABLE NINJA_INSTALL_RESULT)
     if(NOT NINJA_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install ninja-build failed with ${NINJA_INSTALL_RESULT}, try installing ninja-build manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ninja-build failed with ${NINJA_INSTALL_RESULT}, try installing ninja-build manually and then run cmake again")
     else()
         find_program(NINJA_EXECUTABLE ninja REQUIRED)
     endif()
 endif()
 
-# Meson will install the fuse library and header files in the following paths.
-set(fuse3_LIBRARY "/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/libfuse3.a")
+# Decide fuse3 paths based on ENABLE_DYNAMIC_LINKS.
+if(ENABLE_DYNAMIC_LINKS)
+    # Dynamic: Meson installs directly to /usr/local/lib.
+    set(fuse3_LIBRARY "/usr/local/lib/libfuse3.a")
+else()
+    # Static: Use multiarch layout.
+    set(fuse3_LIBRARY "/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/libfuse3.a")
+endif()
+
+# Include path remains the same for both cases.
 set(fuse3_INCLUDE_DIR "/usr/local/include")
+
+# Meson will install the fuse library and header files in the following paths.
+# set(fuse3_LIBRARY "/usr/local/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/libfuse3.a")
+# set(fuse3_INCLUDE_DIR "/usr/local/include")
 
 add_custom_command(
     OUTPUT ${fuse3_LIBRARY}
@@ -210,10 +232,15 @@ add_custom_target(libfuse ALL DEPENDS ${fuse3_LIBRARY})
 find_package(GnuTLS "3.4.6" QUIET)
 if(NOT GNUTLS_FOUND)
     message(STATUS "GnuTLS not found, trying to install gnutls-dev!")
-    execute_process(COMMAND sudo apt install -y gnutls-dev
+    if(PKG_MGR STREQUAL "apt")
+        set(GNUTLS_PKG "gnutls-dev")
+    else()
+        set(GNUTLS_PKG "gnutls-devel")
+    endif()
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ${GNUTLS_PKG}
                     RESULT_VARIABLE GNUTLS_INSTALL_RESULT)
     if(NOT GNUTLS_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install gnutls-dev failed with ${GNUTLS_INSTALL_RESULT}, try installing gnutls-dev manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ${GNUTLS_PKG} failed with ${GNUTLS_INSTALL_RESULT}, try installing ${GNUTLS_PKG} manually and then run cmake again")
     else()
         find_package(GnuTLS "3.4.6" REQUIRED)
     endif()
@@ -229,11 +256,16 @@ endif()
 
 find_package(tcmalloc QUIET)
 if(NOT tcmalloc_FOUND)
-    message(STATUS "tcmalloc not found, trying to install libgoogle-perftools-dev!")
-    execute_process(COMMAND sudo apt install -y libgoogle-perftools-dev
+    if(PKG_MGR STREQUAL "apt")
+        set(TCMALLOC_PKG "libgoogle-perftools-dev")
+    else()
+        set(TCMALLOC_PKG "gperftools-devel")
+    endif()
+    message(STATUS "tcmalloc not found, trying to install ${TCMALLOC_PKG}!")
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ${TCMALLOC_PKG}
             RESULT_VARIABLE tcmalloc_INSTALL_RESULT)
     if(NOT tcmalloc_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install libgoogle-perftools-dev failed with ${tcmalloc_INSTALL_RESULT}, try installing libgoogle-perftools-dev manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ${TCMALLOC_PKG} failed with ${tcmalloc_INSTALL_RESULT}, try installing ${TCMALLOC_PKG} manually and then run cmake again")
     else()
         # Call once more to ensure above install completed fine and also
         # will set tcmalloc_INCLUDE_DIR and tcmalloc_LIBRARY variables.
@@ -256,20 +288,29 @@ endif()
 pkg_search_module(JEMALLOC QUIET jemalloc)
 
 if(NOT JEMALLOC_FOUND)
-    message(STATUS "jemalloc not found, trying to install libjemalloc-dev!")
-    execute_process(COMMAND sudo apt install -y libjemalloc-dev
+    if(${PKG_MGR} STREQUAL "tdnf")
+        set(JEMALLOC_PKG jemalloc-devel)
+    else()
+        set(JEMALLOC_PKG libjemalloc-dev)
+    endif()
+    message(STATUS "jemalloc not found, trying to install ${JEMALLOC_PKG}!")
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ${JEMALLOC_PKG}
             RESULT_VARIABLE JEMALLOC_INSTALL_RESULT)
     if(NOT JEMALLOC_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install libjemalloc-dev failed with ${JEMALLOC_INSTALL_RESULT}, try installing libjemalloc-dev manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ${JEMALLOC_PKG} failed with ${JEMALLOC_INSTALL_RESULT}, try installing ${JEMALLOC_PKG} manually and then run cmake again")
     else()
         # Call once more to ensure above install completed fine and also
-        # will set JEMALLOC_LIBRARY_DIRS variable.
+        # will set JEMALLOC_LIBRARIES variable.
         pkg_search_module(JEMALLOC REQUIRED jemalloc)
     endif()
 endif()
 
-# We want to link against the static jemalloc lib.
-message(STATUS "Using jemalloc static lib ${JEMALLOC_LIBRARY_DIRS}/libjemalloc.a")
+if(ENABLE_DYNAMIC_LINKS)
+    message(STATUS "Using jemalloc lib ${JEMALLOC_LIBRARIES}")
+else()
+    # We want to link against the static jemalloc lib.
+    message(STATUS "Using jemalloc static lib ${JEMALLOC_LIBRARY_DIRS}")
+endif()
 endif()
 
 #
@@ -277,11 +318,16 @@ endif()
 #
 pkg_search_module(UUID QUIET uuid)
 if(NOT UUID_FOUND)
-    message(STATUS "uuid not found, trying to install uuid-dev!")
-    execute_process(COMMAND sudo apt install -y uuid-dev
+    if(PKG_MGR STREQUAL "apt")
+        set(UUID_PKG "uuid-dev")
+    else()
+        set(UUID_PKG "uuid-devel")
+    endif()
+    message(STATUS "uuid not found, trying to install ${UUID_PKG}!")
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ${UUID_PKG}
             RESULT_VARIABLE UUID_INSTALL_RESULT)
     if(NOT UUID_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install uuid-dev failed with ${UUID_INSTALL_RESULT}, try installing uuid-dev manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ${UUID_PKG} failed with ${UUID_INSTALL_RESULT}, try installing ${UUID_PKG} manually and then run cmake again")
     else()
         pkg_search_module(UUID REQUIRED uuid)
     endif()
@@ -295,11 +341,16 @@ message(STATUS "Using uuid include dir ${UUID_INCLUDE_DIRS}")
 #
 find_package(ZLIB QUIET)
 if(NOT ZLIB_FOUND)
-    message(STATUS "zlib not found, trying to install zlib1g-dev!")
-    execute_process(COMMAND sudo apt install -y zlib1g-dev
+    if(PKG_MGR STREQUAL "apt")
+        set(ZLIB_PKG "zlib1g-dev")
+    else()
+        set(ZLIB_PKG "zlib-devel")
+    endif()
+    message(STATUS "zlib not found, trying to install ${ZLIB_PKG}!")
+    execute_process(COMMAND sudo ${PKG_MGR} install -y ${ZLIB_PKG}
 		    RESULT_VARIABLE ZLIB_INSTALL_RESULT)
     if(NOT ZLIB_INSTALL_RESULT EQUAL "0")
-        message(FATAL_ERROR "apt install zlib1g-dev failed with ${ZLIB_INSTALL_RESULT}, try installing zlib1g-dev manually and then run cmake again")
+        message(FATAL_ERROR "${PKG_MGR} install ${ZLIB_PKG} failed with ${ZLIB_INSTALL_RESULT}, try installing ${ZLIB_PKG} manually and then run cmake again")
     else()
         # Call once more to ensure above install completed fine and also
         # will set ZLIB_INCLUDE_DIR and ZLIB_LIBRARY variables.
@@ -377,66 +428,85 @@ target_compile_options(${CMAKE_PROJECT_NAME}
                        PRIVATE -Werror
                        )
 
-#
-# Libraries for statically linking gnutls.
-# libp11-kit and libunistring do not have a static version available, so we are
-# forced to use the shared version and bundle it.
-#
-set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+# Only use static gnutls linking when ENABLE_DYNAMIC_LINKS is NOT set.
+if(NOT ENABLE_DYNAMIC_LINKS)
+    #
+    # Libraries for statically linking gnutls.
+    # libp11-kit and libunistring do not have a static version available, so we are
+    # forced to use the shared version and bundle it.
+    #
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
 
-find_library(GNUTLS_STATIC_LIB libgnutls.a REQUIRED)
-#
-# arm64 libgnutls.a has multiple definitions for some symbols exported by
-# libcrypto.a. The libcrypto.a object has some more symbols which are needed,
-# so we delete the offending object from libgnutls.a before linking.
-#
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-execute_process(
-	COMMAND bash -c "cp -vf ${GNUTLS_STATIC_LIB} /tmp/gnutls.a; ar dv /tmp/gnutls.a aes-aarch64.o"
-	COMMAND_ERROR_IS_FATAL ANY)
-set(GNUTLS_STATIC_LIB /tmp/gnutls.a)
+    find_library(GNUTLS_STATIC_LIB libgnutls.a REQUIRED)
+    #
+    # arm64 libgnutls.a has multiple definitions for some symbols exported by
+    # libcrypto.a. The libcrypto.a object has some more symbols which are needed,
+    # so we delete the offending object from libgnutls.a before linking.
+    #
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    execute_process(
+        COMMAND bash -c "cp -vf ${GNUTLS_STATIC_LIB} /tmp/gnutls.a; ar dv /tmp/gnutls.a aes-aarch64.o"
+        COMMAND_ERROR_IS_FATAL ANY)
+    set(GNUTLS_STATIC_LIB /tmp/gnutls.a)
+    endif()
+
+    find_library(HOGWEED_STATIC_LIB libhogweed.a REQUIRED)
+    find_library(NETTLE_STATIC_LIB libnettle.a REQUIRED)
+    find_library(TASN1_STATIC_LIB libtasn1.a REQUIRED)
+    find_library(IDN2_STATIC_LIB libidn2.a REQUIRED)
+    find_library(GMP_STATIC_LIB libgmp.a REQUIRED)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
+    find_library(P11_KIT_SHARED_LIB libp11-kit.so REQUIRED)
+    find_library(UNISTRING_SHARED_LIB NAMES
+                libunistring.so
+                libunistring.so.5
+                libunistring.so.2
+                REQUIRED)
+
+    set(GNUTLS_ALL_LIBRARIES
+        ${GNUTLS_STATIC_LIB}
+        ${HOGWEED_STATIC_LIB}
+        ${NETTLE_STATIC_LIB}
+        ${TASN1_STATIC_LIB}
+        ${IDN2_STATIC_LIB}
+        ${GMP_STATIC_LIB}
+        ${P11_KIT_SHARED_LIB}
+        ${UNISTRING_SHARED_LIB})
+    message(STATUS "Using gnutls libraries: ${GNUTLS_ALL_LIBRARIES}")
 endif()
 
-find_library(HOGWEED_STATIC_LIB libhogweed.a REQUIRED)
-find_library(NETTLE_STATIC_LIB libnettle.a REQUIRED)
-find_library(TASN1_STATIC_LIB libtasn1.a REQUIRED)
-find_library(IDN2_STATIC_LIB libidn2.a REQUIRED)
-find_library(GMP_STATIC_LIB libgmp.a REQUIRED)
-set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
-find_library(P11_KIT_SHARED_LIB libp11-kit.so REQUIRED)
-find_library(UNISTRING_SHARED_LIB NAMES
-             libunistring.so
-             libunistring.so.5
-             libunistring.so.2
-             REQUIRED)
-
-set(GNUTLS_ALL_LIBRARIES
-    ${GNUTLS_STATIC_LIB}
-    ${HOGWEED_STATIC_LIB}
-    ${NETTLE_STATIC_LIB}
-    ${TASN1_STATIC_LIB}
-    ${IDN2_STATIC_LIB}
-    ${GMP_STATIC_LIB}
-    ${P11_KIT_SHARED_LIB}
-    ${UNISTRING_SHARED_LIB})
-message(STATUS "Using gnutls libraries: ${GNUTLS_ALL_LIBRARIES}")
-
 # All libraries.
-target_link_libraries(${CMAKE_PROJECT_NAME}
-                      -static-libgcc -static-libstdc++
-                      -Wl,-rpath,/opt/microsoft/aznfs/libs
-                      ${ZLIB_LIBRARIES}
-                      dl
-                      pthread
-                      nfs
-                      # GNUTLS libraries are needed by static libnfs.
-                      ${GNUTLS_ALL_LIBRARIES}
-                      yaml-cpp
-                      spdlog
-                      Azure::azure-identity
-                      Azure::azure-storage-blobs
-                      nlohmann_json::nlohmann_json
-                      uuid)
+if(ENABLE_DYNAMIC_LINKS)
+  # Dynamic linking: No static flags, use GnuTLS::GnuTLS target
+  target_link_libraries(${CMAKE_PROJECT_NAME}
+                        ${ZLIB_LIBRARIES}
+                        dl
+                        pthread
+                        nfs
+                        yaml-cpp
+                        spdlog
+                        Azure::azure-identity
+                        Azure::azure-storage-blobs
+                        nlohmann_json::nlohmann_json
+                        uuid
+                        GnuTLS::GnuTLS)
+else()
+  # Static linking: Use static-libgcc/libstdc++ and explicit gnutls libraries
+  target_link_libraries(${CMAKE_PROJECT_NAME}
+                        -static-libgcc -static-libstdc++
+                        -Wl,-rpath,/opt/microsoft/aznfs/libs
+                        ${ZLIB_LIBRARIES}
+                        dl
+                        pthread
+                        nfs
+                        ${GNUTLS_ALL_LIBRARIES}
+                        yaml-cpp
+                        spdlog
+                        Azure::azure-identity
+                        Azure::azure-storage-blobs
+                        nlohmann_json::nlohmann_json
+                        uuid)
+endif()
 
 if(ENABLE_TCMALLOC)
 target_link_libraries(${CMAKE_PROJECT_NAME}
@@ -444,8 +514,21 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
 endif()
 
 if(ENABLE_JEMALLOC)
-target_link_libraries(${CMAKE_PROJECT_NAME}
-                      ${JEMALLOC_LIBRARY_DIRS}/libjemalloc.a)
+  if(ENABLE_DYNAMIC_LINKS)
+    target_link_libraries(${CMAKE_PROJECT_NAME}
+                          ${JEMALLOC_LIBRARIES})
+  else()
+    target_link_libraries(${CMAKE_PROJECT_NAME}
+                          ${JEMALLOC_LIBRARY_DIRS}/libjemalloc.a)
+  endif()
 endif()
+
+# --- Debug: Print all static libraries linked ---
+get_target_property(LINK_LIBS ${CMAKE_PROJECT_NAME} LINK_LIBRARIES)
+message(STATUS "==== Libraries linked to ${CMAKE_PROJECT_NAME} ====")
+foreach(lib IN LISTS LINK_LIBS)
+    message(STATUS "  ${lib}")
+endforeach()
+message(STATUS "===============================================")
 
 install(TARGETS ${CMAKE_PROJECT_NAME})

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -577,12 +577,4 @@ if(ENABLE_JEMALLOC)
   endif()
 endif()
 
-# --- Debug: Print all static libraries linked ---
-get_target_property(LINK_LIBS ${CMAKE_PROJECT_NAME} LINK_LIBRARIES)
-message(STATUS "==== Libraries linked to ${CMAKE_PROJECT_NAME} ====")
-foreach(lib IN LISTS LINK_LIBS)
-    message(STATUS "  ${lib}")
-endforeach()
-message(STATUS "===============================================")
-
 install(TARGETS ${CMAKE_PROJECT_NAME})

--- a/turbonfs/CMakeLists.txt
+++ b/turbonfs/CMakeLists.txt
@@ -184,7 +184,7 @@ if(ENABLE_DYNAMIC_LINKS)
     # For dynamic builds, use system-installed fuse3 shared library
     #
     message(STATUS "Using system-installed fuse3 (dynamic linking)")
-    pkg_search_module(FUSE3 REQUIRED fuse3)
+    pkg_search_module(FUSE3 REQUIRED fuse3-devel)
     
     if(NOT FUSE3_FOUND)
         message(FATAL_ERROR "fuse3 not found! Please install fuse3-devel package: sudo tdnf install -y fuse3-devel")
@@ -193,6 +193,15 @@ if(ENABLE_DYNAMIC_LINKS)
     message(STATUS "Found fuse3 libraries: ${FUSE3_LIBRARIES}")
     message(STATUS "Found fuse3 include dirs: ${FUSE3_INCLUDE_DIRS}")
     message(STATUS "Found fuse3 library dirs: ${FUSE3_LIBRARY_DIRS}")
+
+    target_include_directories(${CMAKE_PROJECT_NAME}
+        PRIVATE
+        ${FUSE3_INCLUDE_DIRS}
+    )
+
+    target_link_libraries(${CMAKE_PROJECT_NAME}
+        ${FUSE3_LIBRARIES}
+    )
 else()
     #
     # For static builds, build libfuse from source

--- a/turbonfs/build.sh
+++ b/turbonfs/build.sh
@@ -10,6 +10,39 @@ RELEASE_NUMBER="0.0.1"
 
 export VCPKG_ROOT=extern/vcpkg
 
+is_azurelinux()
+{
+    if [ ! -r /etc/os-release ]; then
+        return 1
+    fi
+
+    . /etc/os-release
+    [ "${ID:-}" == "azurelinux" ] || [ "${ID:-}" == "mariner" ] || \
+        [[ " ${ID_LIKE:-} " == *" azurelinux "* ]] || [[ " ${ID_LIKE:-} " == *" mariner "* ]]
+}
+
+normalize_cmake_bool()
+{
+    case "$1" in
+        1|ON|On|on|TRUE|True|true|YES|Yes|yes)
+            echo "ON"
+            ;;
+        *)
+            echo "OFF"
+            ;;
+    esac
+}
+
+if [ -n "${ENABLE_DYNAMIC_LINKS+x}" ]; then
+    DYNAMIC_LINKS=$(normalize_cmake_bool "${ENABLE_DYNAMIC_LINKS}")
+elif is_azurelinux; then
+    DYNAMIC_LINKS=ON
+else
+    DYNAMIC_LINKS=OFF
+fi
+
+echo "ENABLE_DYNAMIC_LINKS=${DYNAMIC_LINKS}"
+
 # Update (vcpkg) submodules before calling cmake as toolchain build expects it.
 git submodule update --recursive --init
 
@@ -40,6 +73,7 @@ cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DENABLE_JEMALLOC=$JEMALLOC \
       -DENABLE_PARANOID=$PARANOID \
       -DENABLE_INSECURE_AUTH_FOR_DEVTEST=$INSECURE_AUTH_FOR_DEVTEST \
+      -DENABLE_DYNAMIC_LINKS=$DYNAMIC_LINKS \
       -DPACKAGE_VERSION=$RELEASE_NUMBER \
       -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake ..
 


### PR DESCRIPTION
root [ /home/palashvij-azurelinux3 ]# ldd /sbin/aznfsclient
        linux-vdso.so.1 (0x0000f25bc759c000)
        libuuid.so.1 => /usr/lib/libuuid.so.1 (0x0000f25bc6cb0000)
        libgnutls.so.30 => /usr/lib/libgnutls.so.30 (0x0000f25bc6a10000)
        libfuse3.so.3 => /usr/lib/libfuse3.so.3 (0x0000f25bc69b0000)
        libjemalloc.so.2 => /usr/lib/libjemalloc.so.2 (0x0000f25bc6700000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x0000f25bc6470000)
        libm.so.6 => /usr/lib/libm.so.6 (0x0000f25bc63c0000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x0000f25bc6380000)
        libc.so.6 => /usr/lib/libc.so.6 (0x0000f25bc6170000)
        /lib/ld-linux-aarch64.so.1 (0x0000f25bc7550000)
        libp11-kit.so.0 => /usr/lib/libp11-kit.so.0 (0x0000f25bc5fc0000)
        libtasn1.so.6 => /usr/lib/libtasn1.so.6 (0x0000f25bc5f80000)
        libhogweed.so.6 => /usr/lib/libhogweed.so.6 (0x0000f25bc5f10000)
        libnettle.so.8 => /usr/lib/libnettle.so.8 (0x0000f25bc5ea0000)
        libgmp.so.10 => /usr/lib/libgmp.so.10 (0x0000f25bc5e00000)
        libffi.so.8 => /usr/lib/libffi.so.8 (0x0000f25bc5dc0000)
        
        
        
root [ /home/palashvij-azurelinux3 ]# echo "=== Package ==="
rpm -qf /sbin/aznfsclient

echo "=== RPM Dependencies ==="
rpm -qR "$(rpm -qf /sbin/aznfsclient)"

echo "=== Shared Libraries ==="
ldd /sbin/aznfsclient

echo "=== Binary ==="
file /sbin/aznfsclient
=== Package ===
aznfs-0.3.3-1.aarch64
=== RPM Dependencies ===
/bin/bash
/bin/sh
/bin/sh
/bin/sh
/bin/sh
bash
bind-utils
conntrack-tools
fuse3
gnutls
iproute
iptables
jemalloc
ld-linux-aarch64.so.1()(64bit)
ld-linux-aarch64.so.1(GLIBC_2.17)(64bit)
libasan
libc.so.6()(64bit)
libc.so.6(GLIBC_2.17)(64bit)
libc.so.6(GLIBC_2.25)(64bit)
libc.so.6(GLIBC_2.28)(64bit)
libc.so.6(GLIBC_2.30)(64bit)
libc.so.6(GLIBC_2.32)(64bit)
libc.so.6(GLIBC_2.33)(64bit)
libc.so.6(GLIBC_2.34)(64bit)
libc.so.6(GLIBC_2.38)(64bit)
libfuse3.so.3()(64bit)
libfuse3.so.3(FUSE_3.0)(64bit)
libfuse3.so.3(FUSE_3.12)(64bit)
libgcc_s.so.1()(64bit)
libgcc_s.so.1(GCC_3.0)(64bit)
libgcc_s.so.1(GCC_4.5.0)(64bit)
libgnutls.so.30()(64bit)
libgnutls.so.30(GNUTLS_3_4)(64bit)
libgnutls.so.30(GNUTLS_3_7_3)(64bit)
libjemalloc.so.2()(64bit)
libm.so.6()(64bit)
libstdc++.so.6()(64bit)
libstdc++.so.6(CXXABI_1.3)(64bit)
libstdc++.so.6(CXXABI_1.3.11)(64bit)
libstdc++.so.6(CXXABI_1.3.13)(64bit)
libstdc++.so.6(CXXABI_1.3.2)(64bit)
libstdc++.so.6(CXXABI_1.3.3)(64bit)
libstdc++.so.6(CXXABI_1.3.5)(64bit)
libstdc++.so.6(CXXABI_1.3.7)(64bit)
libstdc++.so.6(GLIBCXX_3.4)(64bit)
libstdc++.so.6(GLIBCXX_3.4.11)(64bit)
libstdc++.so.6(GLIBCXX_3.4.14)(64bit)
libstdc++.so.6(GLIBCXX_3.4.15)(64bit)
libstdc++.so.6(GLIBCXX_3.4.18)(64bit)
libstdc++.so.6(GLIBCXX_3.4.19)(64bit)
libstdc++.so.6(GLIBCXX_3.4.20)(64bit)
libstdc++.so.6(GLIBCXX_3.4.21)(64bit)
libstdc++.so.6(GLIBCXX_3.4.22)(64bit)
libstdc++.so.6(GLIBCXX_3.4.26)(64bit)
libstdc++.so.6(GLIBCXX_3.4.29)(64bit)
libstdc++.so.6(GLIBCXX_3.4.30)(64bit)
libstdc++.so.6(GLIBCXX_3.4.32)(64bit)
libstdc++.so.6(GLIBCXX_3.4.9)(64bit)
libuuid.so.1()(64bit)
libuuid.so.1(UUID_1.0)(64bit)
net-tools
newt
nfs-utils
nmap-ncat
procps-ng
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
stunnel
util-linux
=== Shared Libraries ===
        linux-vdso.so.1 (0x0000ffb8f51e8000)
        libuuid.so.1 => /usr/lib/libuuid.so.1 (0x0000ffb8f4900000)
        libgnutls.so.30 => /usr/lib/libgnutls.so.30 (0x0000ffb8f4660000)
        libfuse3.so.3 => /usr/lib/libfuse3.so.3 (0x0000ffb8f4600000)
        libjemalloc.so.2 => /usr/lib/libjemalloc.so.2 (0x0000ffb8f4350000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x0000ffb8f40c0000)
        libm.so.6 => /usr/lib/libm.so.6 (0x0000ffb8f4010000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x0000ffb8f3fd0000)
        libc.so.6 => /usr/lib/libc.so.6 (0x0000ffb8f3dc0000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffb8f51a0000)
        libp11-kit.so.0 => /usr/lib/libp11-kit.so.0 (0x0000ffb8f3c10000)
        libtasn1.so.6 => /usr/lib/libtasn1.so.6 (0x0000ffb8f3bd0000)
        libhogweed.so.6 => /usr/lib/libhogweed.so.6 (0x0000ffb8f3b60000)
        libnettle.so.8 => /usr/lib/libnettle.so.8 (0x0000ffb8f3af0000)
        libgmp.so.10 => /usr/lib/libgmp.so.10 (0x0000ffb8f3a50000)
        libffi.so.8 => /usr/lib/libffi.so.8 (0x0000ffb8f3a10000)
=== Binary ===
/sbin/aznfsclient: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=c9636dbe97b14f540e2fdee912634e9ae52e433c, for GNU/Linux 4.14.0, not stripped
root [ /home/palashvij-azurelinux3 ]# 


<img width="485" height="250" alt="image" src="https://github.com/user-attachments/assets/71b20e32-5ded-461a-8678-3a3607e3d41c" />
<img width="794" height="160" alt="image" src="https://github.com/user-attachments/assets/06291967-e716-4d5e-92fb-1b7ff274b1d0" />
