### PR TITLE
Enable AZNFS on Debian 12(trixie) & 13 (trixie)

### DIFF
--- a/.github/aznfs-build.yaml
+++ b/.github/aznfs-build.yaml
@@ -61,10 +61,11 @@ stages:
 
           - script: |
               mkdir -p $(Build.ArtifactStagingDirectory)/artifacts
-              for dir in deb rpm suse stunnel rpmnewkey susenewkey; do
+              for dir in deb rpm suse stunnel rpmnewkey susenewkey debnewkey; do
                 mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/$dir
               done
               cp -f $(System.DefaultWorkingDirectory)/deb/aznfs-${{ parameters.versionName }}-1_amd64.deb $(Build.ArtifactStagingDirectory)/artifacts/deb
+              cp -f $(System.DefaultWorkingDirectory)/deb/aznfs-${{ parameters.versionName }}-1_amd64.deb $(Build.ArtifactStagingDirectory)/artifacts/debnewkey
               cp -f $(System.DefaultWorkingDirectory)/rpm/root/rpmbuild/RPMS/x86_64/aznfs-${{ parameters.versionName }}-1.x86_64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpmnewkey
               cp -f $(System.DefaultWorkingDirectory)/suse/root/rpmbuild/RPMS/x86_64/aznfs-${{ parameters.versionName }}-1.x86_64.rpm $(Build.ArtifactStagingDirectory)/artifacts/susenewkey
               for dir in rpm suse stunnel; do
@@ -110,10 +111,11 @@ stages:
 
           - script: |
               mkdir -p $(Build.ArtifactStagingDirectory)/artifacts
-              for dir in deb rpm suse stunnel rpmnewkey susenewkey; do
+              for dir in deb rpm suse stunnel rpmnewkey susenewkey debnewkey; do
                 mkdir -p $(Build.ArtifactStagingDirectory)/artifacts/$dir
               done
               cp -avf $(System.DefaultWorkingDirectory)/deb/aznfs-${{ parameters.versionName }}-1_arm64.deb $(Build.ArtifactStagingDirectory)/artifacts/deb
+              cp -avf $(System.DefaultWorkingDirectory)/deb/aznfs-${{ parameters.versionName }}-1_arm64.deb $(Build.ArtifactStagingDirectory)/artifacts/debnewkey
               cp -avf $(System.DefaultWorkingDirectory)/rpm/root/rpmbuild/RPMS/aarch64/aznfs-${{ parameters.versionName }}-1.aarch64.rpm $(Build.ArtifactStagingDirectory)/artifacts/rpmnewkey
               cp -avf $(System.DefaultWorkingDirectory)/suse/root/rpmbuild/RPMS/aarch64/aznfs-${{ parameters.versionName }}-1.aarch64.rpm $(Build.ArtifactStagingDirectory)/artifacts/susenewkey
               for dir in rpm suse stunnel; do
@@ -182,6 +184,35 @@ stages:
                 [
                 {
                   "KeyCode": "CP-450779-Pgp",
+                  "OperationCode": "LinuxSign",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {}
+                }
+                ]
+
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP CodeSigning MI DEB New Key'
+            inputs:
+              ConnectedServiceName: 'Azure AZNFS'
+              AppRegistrationClientId: $(AppRegistrationClientId)
+              AppRegistrationTenantId: $(AppRegistrationTenantId)
+
+              UseMSIAuthentication: true
+              AuthAKVName: $(AuthAKVName)
+              AuthSignCertName: $(AuthSignCertName)
+
+              FolderPath: $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/debnewkey
+              Pattern: '*.deb'
+              SessionTimeout: 90
+              ServiceEndpointUrl: 'https://api.esrp.microsoft.com/api/v2'
+              MaxConcurrency: 25
+              signConfigType: inlineSignParams
+              VerboseLogin: true
+              inlineOperation: |
+                [
+                {
+                  "KeyCode": "CP-500207-Pgp",
                   "OperationCode": "LinuxSign",
                   "ToolName": "sign",
                   "ToolVersion": "1.0",
@@ -337,6 +368,7 @@ stages:
            # Validate signed images have md5sum changed
           - script: |
               chmod 755 $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/deb/*.deb
+              chmod 755 $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/debnewkey/*.deb
               chmod 755 $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/*/*.rpm
               rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/*.md
               rm -rf $(Build.ArtifactStagingDirectory)/aznfs-temp/artifacts/*/*.md
@@ -411,6 +443,12 @@ stages:
 
                   aznfsArm=`pmc --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $(Build.ArtifactStagingDirectory)/aznfs-signed/artifacts/deb/aznfs*-1_arm64.deb`
                   echo "AZNFS ARM DEB Package ID: $aznfsArm"
+
+                  aznfsDebNewKey=`pmc --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $(Build.ArtifactStagingDirectory)/aznfs-signed/artifacts/debnewkey/aznfs*-1_amd64.deb`
+                  echo "AZNFS DEB New Key Package ID: $aznfsDebNewKey"
+
+                  aznfsArmNewKey=`pmc --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $(Build.ArtifactStagingDirectory)/aznfs-signed/artifacts/debnewkey/aznfs*-1_arm64.deb`
+                  echo "AZNFS ARM DEB New Key Package ID: $aznfsArmNewKey"
 
                   aznfsRpm=`pmc --base-url "https://pmc-ingest.trafficmanager.net/api/v4" --id-only package upload $(Build.ArtifactStagingDirectory)/aznfs-signed/artifacts/rpm/aznfs*-1.x86_64.rpm`
                   echo "AZNFS RPM Package ID: $aznfsRpm"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ the watchdog process restarts it.
 
 AZNFS is supported on following Linux distros:
 
+- Debian (12, 13)
 - Ubuntu (18.04 LTS, 20.04 LTS, 22.04, 24.04 LTS, 26.04 LTS)
 - Centos7, Centos8
 - RedHat7, RedHat8, RedHat9, RedHat10

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1057,7 +1057,7 @@ ensure_iptable_entry()
 
 #
 # We only use lowercase single word names for distro id:
-# ubuntu, centos, redhat, sles.
+# debian, ubuntu, centos, redhat, sles.
 #
 canonicalize_distro_id()
 {
@@ -1100,7 +1100,7 @@ log_version_info()
     #
     sleep 2
 
-    if [ "$distro_id" == "ubuntu" ]; then
+    if [ "$distro_id" == "ubuntu" -o "$distro_id" == "debian" ]; then
         current_version=$(dpkg-query -W -f='${Version}\n' aznfs 2>/dev/null)
     elif [ "$distro_id" == "centos" -o "$distro_id" == "rocky" -o "$distro_id" == "rhel" -o "$distro_id" == "ol" -o "$distro_id" == "azurelinux" ]; then
         current_pkg_name=$(rpm -q aznfs)

--- a/packages.csv
+++ b/packages.csv
@@ -1,5 +1,9 @@
 # Do not remove these comments - the list should start at line #3
 # Format of the file : <Distro Name>,<Architecture, File Type>,<Repo Name>,<Release Name(for deb repos only)>
+Debian-12,aznfsDeb,microsoft-debian-bookworm-prod-apt,bookworm
+Debian-12,aznfsArm,microsoft-debian-bookworm-prod-apt,bookworm
+Debian-13,aznfsDeb,microsoft-debian-trixie-prod-apt,trixie
+Debian-13,aznfsArm,microsoft-debian-trixie-prod-apt,trixie
 Ubuntu-18.04,aznfsDeb,microsoft-ubuntu-bionic-prod-apt,bionic
 Ubuntu-18.04,aznfsArm,microsoft-ubuntu-bionic-prod-apt,bionic
 Ubuntu-20.04,aznfsDeb,microsoft-ubuntu-focal-prod-apt,focal

--- a/packages.csv
+++ b/packages.csv
@@ -1,9 +1,9 @@
 # Do not remove these comments - the list should start at line #3
 # Format of the file : <Distro Name>,<Architecture, File Type>,<Repo Name>,<Release Name(for deb repos only)>
-Debian-12,aznfsDeb,microsoft-debian-bookworm-prod-apt,bookworm
-Debian-12,aznfsArm,microsoft-debian-bookworm-prod-apt,bookworm
-Debian-13,aznfsDeb,microsoft-debian-trixie-prod-apt,trixie
-Debian-13,aznfsArm,microsoft-debian-trixie-prod-apt,trixie
+Debian-12,aznfsDebNewKey,microsoft-debian-bookworm-prod-apt,bookworm
+Debian-12,aznfsArmNewKey,microsoft-debian-bookworm-prod-apt,bookworm
+Debian-13,aznfsDebNewKey,microsoft-debian-trixie-prod-apt,trixie
+Debian-13,aznfsArmNewKey,microsoft-debian-trixie-prod-apt,trixie
 Ubuntu-18.04,aznfsDeb,microsoft-ubuntu-bionic-prod-apt,bionic
 Ubuntu-18.04,aznfsArm,microsoft-ubuntu-bionic-prod-apt,bionic
 Ubuntu-20.04,aznfsDeb,microsoft-ubuntu-focal-prod-apt,focal

--- a/packaging/aznfs/DEBIAN/control
+++ b/packaging/aznfs/DEBIAN/control
@@ -1,9 +1,9 @@
 Package: aznfs
 Version: x.y.z
-Priority: required
+Priority: optional
 Architecture: BUILD_ARCH
 Origin: Microsoft
 Maintainer: Azure Storage XNFS Team <aznfs@microsoft.com>
 Homepage: https://github.com/Azure/AZNFS-mount/blob/main/README.md
 Description: Mount helper program for Azure Blob NFS mounts, providing a secure communication channel for Azure File NFS mounts, and supporting the Turbo NFS client
-Depends: bash, procps, conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat, sysvinit-utils, whiptail, stunnel4, net-tools, libasan6
+Depends: bash, procps, conntrack, iptables, bind9-host, iproute2, util-linux, nfs-common, netcat, sysvinit-utils, whiptail, stunnel4, net-tools

--- a/scripts/aznfs_install.sh
+++ b/scripts/aznfs_install.sh
@@ -111,7 +111,7 @@ use_dnf_or_yum()
 #
 # This returns distro id in a canonical form, that rest of the code understands.
 # We only use lowercase single word names for distro names:
-# ubuntu, centos, redhat, sles.
+# debian, ubuntu, centos, redhat, sles.
 #
 canonicalize_distro_id()
 {
@@ -134,7 +134,7 @@ ensure_pkg()
 {
     local distro="$distro_id"
 
-    if [ "$distro" == "ubuntu" ]; then
+    if [ "$distro" == "ubuntu" -o "$distro" == "debian" ]; then
         apt -y update
         if [ $? -ne 0 ]; then
             echo


### PR DESCRIPTION
- scripts/aznfs_install.sh: treat 'debian' like 'ubuntu' (apt path). ID=debian already canonicalizes to 'debian', it was only missing from the package-manager branch, which made the installer FATAL with "Unsupported linux distro <debian>".
- lib/common.sh: keep the sibling canonicalize copy consistent - document 'debian' in the canonical list and route its aznfs version lookup through the dpkg (apt) branch in log_version_info (else it reported "Unknown").
- packaging/aznfs/DEBIAN/control: drop the hard 'libasan6' dependency. It is vestigial: aznfsclient's shared libs (incl. libasan when built with ASAN) are already bundled into /opt/microsoft/aznfs/libs via the containerization step in generate_package.sh. libasan6 does not exist on Debian 13 (trixie ships libasan8) nor Ubuntu 20.04/24.04/26.04, so the hard dep made the .deb uninstallable there.
- packages.csv: publish the deb to the Debian 12 (bookworm) & 13 (trixie) PMC apt repo.
- README.md: list Debian 12 & 13 under Supported Distros.