### PR TITLE
Turbo ACL Bug Fix

### DIFF
--- a/turbonfs/inc/connection.h
+++ b/turbonfs/inc/connection.h
@@ -4,6 +4,8 @@
 #include "aznfsc.h"
 #include "nfs_internal.h"
 
+#include <mutex>
+
 /**
  * This represents one connection to the NFS server.
  * For achieving higher throughput we can have more than one connections to the
@@ -26,6 +28,12 @@ private:
      * This is initialized when the connection is started.
      */
     struct nfs_context *nfs_context = nullptr;
+
+    /*
+     * Serializes AUTH_UNIX updates with PDU creation on this context.
+     * Recursive locking permits an inline callback to issue another RPC.
+     */
+    std::recursive_mutex credential_mutex_45;
 
     /*
      * Integral index of this connection in the rpc_transport's connection
@@ -55,6 +63,11 @@ public:
     struct nfs_context* get_nfs_context() const
     {
         return nfs_context;
+    }
+
+    std::recursive_mutex& get_credential_mutex()
+    {
+        return credential_mutex_45;
     }
 
     /*

--- a/turbonfs/inc/nfs_client.h
+++ b/turbonfs/inc/nfs_client.h
@@ -27,6 +27,7 @@
  * - bytes_chunk_cache::chunkmap_lock_43
  * - membuf::mb_lock_44
  * - membuf::flush_waiters_lock_44
+ * - nfs_connection::credential_mutex_45
  */
 
 extern "C" {
@@ -307,6 +308,9 @@ public:
      */
     struct nfs_context* get_nfs_context(conn_sched_t csched,
                                         uint32_t fh_hash) const;
+
+    std::recursive_mutex& get_credential_mutex(
+        const struct nfs_context *nfs) const;
 
     /*
      * Given an inode number, return the nfs_inode structure.

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -1,6 +1,8 @@
 #ifndef __RPC_TASK_H__
 #define __RPC_TASK_H__
 
+#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <string>
 #include <mutex>
@@ -2121,7 +2123,7 @@ public:
     }
 
     /**
-        * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid.
+     * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid/groups.
      *
      * The FUSE daemon runs as root, so libnfs defaults to uid=0/gid=0
      * in the RPC AUTH_UNIX header. With root_squash enabled on the
@@ -2153,6 +2155,21 @@ public:
             struct nfs_context *nfs = get_nfs_context();
             nfs_set_uid(nfs, ctx->uid);
             nfs_set_gid(nfs, ctx->gid);
+
+            constexpr int AUTH_UNIX_MAX_AUXILIARY_GIDS = 16;
+            std::array<gid_t, AUTH_UNIX_MAX_AUXILIARY_GIDS> fuse_gids{};
+            const int group_count = fuse_req_getgroups(
+                req, static_cast<int>(fuse_gids.size()), fuse_gids.data());
+            const int gids_to_copy = std::clamp(
+                group_count, 0, AUTH_UNIX_MAX_AUXILIARY_GIDS);
+            std::array<uint32_t, AUTH_UNIX_MAX_AUXILIARY_GIDS>
+                auxiliary_gids{};
+            for (int i = 0; i < gids_to_copy; i++) {
+                auxiliary_gids[i] = static_cast<uint32_t>(fuse_gids[i]);
+            }
+            nfs_set_auxiliary_gids(nfs,
+                                   static_cast<uint32_t>(gids_to_copy),
+                                   auxiliary_gids.data());
         }
     }
 

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2129,16 +2129,13 @@ public:
      * in the RPC AUTH_UNIX header. With root_squash enabled on the
      * server, this causes ALL operations to be squashed to nobody.
      *
-     * This must be called before the rpc_nfs3_*_task() call so that
-     * rpc_allocate_pdu() picks up the correct AUTH credentials.
+    * Credential updates and PDU allocation must hold the selected
+    * connection's credential mutex as one operation.
      * For child/backend tasks where get_fuse_req() is null (for example
      * READ/WRITE backend tasks), we inherit the request context from the
      * parent task so each RPC still carries the correct caller identity.
-     * Thread safety: nfs_set_uid/gid internally calls rpc_set_uid_gid
-     * which replaces rpc->auth. The rpc_mutex inside libnfs protects
-     * the auth update and PDU allocation atomically.
      */
-    void set_caller_credentials()
+    void set_caller_credentials(struct nfs_context *nfs)
     {
         fuse_req *req = get_fuse_req();
 
@@ -2152,7 +2149,6 @@ public:
 
         const fuse_ctx *ctx = fuse_req_ctx(req);
         if (ctx) {
-            struct nfs_context *nfs = get_nfs_context();
             nfs_set_uid(nfs, ctx->uid);
             nfs_set_gid(nfs, ctx->gid);
 
@@ -2171,6 +2167,32 @@ public:
                                    static_cast<uint32_t>(gids_to_copy),
                                    auxiliary_gids.data());
         }
+    }
+
+    template <typename Args>
+    struct rpc_pdu *issue_rpc_with_credentials(
+        struct rpc_pdu *(*issue_rpc)(struct rpc_context *, rpc_cb, Args *,
+                                     void *),
+        rpc_cb callback,
+        Args *args,
+        void *private_data)
+    {
+        struct nfs_context *nfs = get_nfs_context();
+        std::lock_guard<std::recursive_mutex> lock(
+            client->get_credential_mutex(nfs));
+        set_caller_credentials(nfs);
+        return issue_rpc(nfs_get_rpc_context(nfs), callback, args,
+                         private_data);
+    }
+
+    template <typename IssueRpc>
+    struct rpc_pdu *issue_rpc_with_credentials(IssueRpc issue_rpc)
+    {
+        struct nfs_context *nfs = get_nfs_context();
+        std::lock_guard<std::recursive_mutex> lock(
+            client->get_credential_mutex(nfs));
+        set_caller_credentials(nfs);
+        return issue_rpc(nfs_get_rpc_context(nfs));
     }
 
     nfs_client *get_client() const

--- a/turbonfs/inc/rpc_task.h
+++ b/turbonfs/inc/rpc_task.h
@@ -2120,6 +2120,42 @@ public:
         return nfs_get_rpc_context(get_nfs_context());
     }
 
+    /**
+        * Set RPC AUTH_UNIX credentials to match the FUSE caller's uid/gid.
+     *
+     * The FUSE daemon runs as root, so libnfs defaults to uid=0/gid=0
+     * in the RPC AUTH_UNIX header. With root_squash enabled on the
+     * server, this causes ALL operations to be squashed to nobody.
+     *
+     * This must be called before the rpc_nfs3_*_task() call so that
+     * rpc_allocate_pdu() picks up the correct AUTH credentials.
+     * For child/backend tasks where get_fuse_req() is null (for example
+     * READ/WRITE backend tasks), we inherit the request context from the
+     * parent task so each RPC still carries the correct caller identity.
+     * Thread safety: nfs_set_uid/gid internally calls rpc_set_uid_gid
+     * which replaces rpc->auth. The rpc_mutex inside libnfs protects
+     * the auth update and PDU allocation atomically.
+     */
+    void set_caller_credentials()
+    {
+        fuse_req *req = get_fuse_req();
+
+        if ((req == nullptr) && rpc_api && rpc_api->parent_task) {
+            req = rpc_api->parent_task->get_fuse_req();
+        }
+
+        if (req == nullptr) {
+            return;
+        }
+
+        const fuse_ctx *ctx = fuse_req_ctx(req);
+        if (ctx) {
+            struct nfs_context *nfs = get_nfs_context();
+            nfs_set_uid(nfs, ctx->uid);
+            nfs_set_gid(nfs, ctx->gid);
+        }
+    }
+
     nfs_client *get_client() const
     {
         assert (client != nullptr);

--- a/turbonfs/inc/rpc_transport.h
+++ b/turbonfs/inc/rpc_transport.h
@@ -163,6 +163,9 @@ public:
     struct nfs_context *get_nfs_context(conn_sched_t csched = CONN_SCHED_FIRST,
                                         uint32_t fh_hash = 0) const;
 
+    std::recursive_mutex& get_credential_mutex(
+        const struct nfs_context *nfs) const;
+
     const std::vector<struct nfs_connection*>& get_all_connections() const
     {
         return nfs_connections;

--- a/turbonfs/src/nfs_client.cpp
+++ b/turbonfs/src/nfs_client.cpp
@@ -278,9 +278,16 @@ void nfs_client::periodic_updater()
      *       commit completes, else we will account for write cache as read.
      */
     const uint64_t cache = bytes_chunk_cache::bytes_allocated_g;
-    const uint64_t wcache = bytes_chunk_cache::bytes_dirty_g +
-                            bytes_chunk_cache::bytes_commit_pending_g;
-    const uint64_t rcache = (uint64_t) std::max((int64_t)(cache - wcache), 0L);
+    const uint64_t sampled_wcache = bytes_chunk_cache::bytes_dirty_g +
+                                    bytes_chunk_cache::bytes_commit_pending_g;
+
+    /*
+     * These counters are independent atomics, so their samples do not form a
+     * coherent snapshot. Clamp writer usage to the sampled total before
+     * deriving reader usage.
+     */
+    const uint64_t wcache = std::min(sampled_wcache, cache);
+    const uint64_t rcache = cache - wcache;
 
     /*
      * Read cache usage as percent of max_cache.
@@ -309,7 +316,7 @@ void nfs_client::periodic_updater()
     const double pct_cache = (cache * 100.0) / max_cache;
 
     assert(pct_cache <= 100.0);
-    assert((pct_rcache + pct_wcache) <= pct_cache);
+    assert((rcache + wcache) == cache);
 
     double rscale = 1.0;
     double wscale = 1.0;

--- a/turbonfs/src/nfs_client.cpp
+++ b/turbonfs/src/nfs_client.cpp
@@ -1157,6 +1157,12 @@ struct nfs_context* nfs_client::get_nfs_context(conn_sched_t csched,
     return transport.get_nfs_context(csched, fh_hash);
 }
 
+std::recursive_mutex& nfs_client::get_credential_mutex(
+    const struct nfs_context *nfs) const
+{
+    return transport.get_credential_mutex(nfs);
+}
+
 void nfs_client::lookup(fuse_req_t req, fuse_ino_t parent_ino, const char* name)
 {
     struct rpc_task *tsk = rpc_task_helper->alloc_rpc_task(FUSE_LOOKUP);

--- a/turbonfs/src/rpc_task.cpp
+++ b/turbonfs/src/rpc_task.cpp
@@ -1078,8 +1078,8 @@ void rpc_task::issue_commit_rpc()
         rpc_retry = false;
         stats.on_rpc_issue();
 
-        if (rpc_nfs3_commit_task(get_rpc_ctx(),
-                                 commit_callback, &args, this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_commit_task,
+                                       commit_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -1570,11 +1570,10 @@ void rpc_task::issue_write_rpc()
         rpc_retry = false;
         stats.on_rpc_issue();
 
-        if (rpc_nfs3_writev_task(get_rpc_ctx(),
-                                 write_iov_callback, &args,
-                                 bciov->iov,
-                                 bciov->iovcnt,
-                                 this) == NULL) {
+        if (issue_rpc_with_credentials([&](struct rpc_context *rpc) {
+            return rpc_nfs3_writev_task(rpc, write_iov_callback, &args,
+                            bciov->iov, bciov->iovcnt, this);
+            }) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -2654,8 +2653,8 @@ void rpc_task::run_lookup()
          *       access the task object after making the libnfs call.
          */
         stats.on_rpc_issue();
-        if (rpc_nfs3_lookup_task(get_rpc_ctx(), lookup_callback, &args,
-                                 this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_lookup_task,
+                           lookup_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -2685,8 +2684,8 @@ void rpc_task::run_access()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_access_task(get_rpc_ctx(), access_callback, &args,
-                                        this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_access_task,
+                           access_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -2898,8 +2897,8 @@ void rpc_task::run_getattr()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_getattr_task(get_rpc_ctx(), getattr_callback, &args,
-                                  this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_getattr_task,
+                           getattr_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -2928,8 +2927,8 @@ void rpc_task::run_statfs()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_fsstat_task(get_rpc_ctx(), statfs_callback, &args,
-                                 this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_fsstat_task,
+                           statfs_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -2971,8 +2970,9 @@ void rpc_task::run_create_file()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_create_task(get_rpc_ctx(), createfile_callback, &args,
-                                 this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_create_task,
+                                       createfile_callback, &args,
+                                       this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3016,8 +3016,8 @@ void rpc_task::run_mknod()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_create_task(get_rpc_ctx(), mknod_callback, &args,
-                                 this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_create_task,
+                                       mknod_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3055,8 +3055,8 @@ void rpc_task::run_mkdir()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_mkdir_task(get_rpc_ctx(), mkdir_callback, &args,
-                                this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_mkdir_task,
+                           mkdir_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3086,8 +3086,8 @@ void rpc_task::run_unlink()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_remove_task(get_rpc_ctx(),
-                                 unlink_callback, &args, this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_remove_task,
+                           unlink_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3118,8 +3118,8 @@ void rpc_task::run_rmdir()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_rmdir_task(get_rpc_ctx(),
-                                rmdir_callback, &args, this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_rmdir_task,
+                           rmdir_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3158,10 +3158,8 @@ void rpc_task::run_symlink()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_symlink_task(get_rpc_ctx(),
-                                         symlink_callback,
-                                         &args,
-                                         this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_symlink_task,
+                                       symlink_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3194,10 +3192,8 @@ void rpc_task::run_rename()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_rename_task(get_rpc_ctx(),
-                                        rename_callback,
-                                        &args,
-                                        this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_rename_task,
+                           rename_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3226,10 +3222,8 @@ void rpc_task::run_readlink()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_readlink_task(get_rpc_ctx(),
-                                          readlink_callback,
-                                          &args,
-                                          this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_readlink_task,
+                           readlink_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -3349,8 +3343,8 @@ void rpc_task::run_setattr()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_setattr_task(get_rpc_ctx(), setattr_callback, &args,
-                                  this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_setattr_task,
+                           setattr_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -4129,13 +4123,13 @@ static void read_callback(
                  */
                 rpc_retry = false;
                 child_tsk->get_stats().on_rpc_issue();
-                if (rpc_nfs3_read_task(
-                        child_tsk->get_rpc_ctx(),
-                        read_callback,
-                        bc->get_buffer() + bc->pvt,
-                        new_size,
-                        &new_args,
-                        (void *) new_ctx) == NULL) {
+                if (child_tsk->issue_rpc_with_credentials(
+                    [&](struct rpc_context *rpc) {
+                        return rpc_nfs3_read_task(
+                        rpc, read_callback,
+                        bc->get_buffer() + bc->pvt, new_size,
+                        &new_args, (void *) new_ctx);
+                    }) == NULL) {
                     child_tsk->get_stats().on_rpc_cancel();
                     /*
                      * Most common reason for this is memory allocation failure,
@@ -4407,13 +4401,11 @@ void rpc_task::read_from_server(struct bytes_chunk &bc)
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_read_task(
-                get_rpc_ctx(), /* This round robins request across connections */
-                read_callback,
-                bc.get_buffer() + bc.pvt,
-                args.count,
-                &args,
-                (void *) ctx) == NULL) {
+            if (issue_rpc_with_credentials([&](struct rpc_context *rpc) {
+                return rpc_nfs3_read_task(rpc, read_callback,
+                              bc.get_buffer() + bc.pvt,
+                              args.count, &args, (void *) ctx);
+                }) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -5509,10 +5501,8 @@ void rpc_task::fetch_readdir_entries_from_server()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_readdir_task(get_rpc_ctx(),
-                                  readdir_callback,
-                                  &args,
-                                  this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_readdir_task,
+                           readdir_callback, &args, this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,
@@ -5575,10 +5565,9 @@ void rpc_task::fetch_readdirplus_entries_from_server()
 
         rpc_retry = false;
         stats.on_rpc_issue();
-        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(),
-                                      readdirplus_callback,
-                                      &args,
-                                      this) == NULL) {
+        if (issue_rpc_with_credentials(rpc_nfs3_readdirplus_task,
+                           readdirplus_callback, &args,
+                           this) == NULL) {
             stats.on_rpc_cancel();
             /*
              * Most common reason for this is memory allocation failure,

--- a/turbonfs/src/rpc_transport.cpp
+++ b/turbonfs/src/rpc_transport.cpp
@@ -239,3 +239,16 @@ struct nfs_context *rpc_transport::get_nfs_context(conn_sched_t csched,
 
     return nfs_connections[idx]->get_nfs_context();
 }
+
+std::recursive_mutex& rpc_transport::get_credential_mutex(
+    const struct nfs_context *nfs) const
+{
+    for (struct nfs_connection *connection : nfs_connections) {
+        if (connection->get_nfs_context() == nfs) {
+            return connection->get_credential_mutex();
+        }
+    }
+
+    assert(0);
+    __builtin_unreachable();
+}


### PR DESCRIPTION
Since the turbo client runs as a FUSE demon, it has a uid=0. When root squash is enabled, even though sattr3 has the correct uid/gid, it is not honored and the uid used is 0. To fix this i have called the setuid and setguid functions before each RPC dispatch

Issue with the earlier commit:
There were some errors while handling supplementary groups.  Some complementary changes were required for the smooth functioning of the tests.

Tests Ran:
Ran the unix test suite. Moreover ran over multiple checks for data integrity and the supplementary group issue using custom scripts. 

Current diff:
turbonfs/inc/connection.h
turbonfs/inc/nfs_client.h
turbonfs/inc/rpc_task.h
turbonfs/inc/rpc_transport.h
turbonfs/src/nfs_client.cpp
turbonfs/src/rpc_task.cpp
turbonfs/src/rpc_transport.cpp